### PR TITLE
Update MacTorcs patch for Torcs 1.3.5

### DIFF
--- a/Headers/isnan.h
+++ b/Headers/isnan.h
@@ -5,7 +5,4 @@
  instead.
  */
 
-#define isnan(x)	\
-(	sizeof (x) == sizeof(float )	?	__inline_isnanf((float)(x))	\
-:	sizeof (x) == sizeof(double)	?	__inline_isnand((double)(x))	\
-:	__inline_isnan ((long double)(x)))
+#define isnan(x) std::isnan(x)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 About
 -----
-This project contains all necessary files to patch and compile the original Torcs 1.3.1 sources into
-a bundled Mac OS X application using Xcode.
+This project contains all necessary files to patch and compile the original Torcs 1.3.5 sources into
+a bundled Mac OS X application using Xcode 5.
 
-The Xcode project is based on previous [work][2] by Stephen Hudson and others, with vast changes to
+The Xcode project is a fork of [MacTorcs][2] by Camillo based on others' work, with vast changes to
 streamline the build, leverage the existing Torcs makefiles for installing data, and reduce the size
 of the final application bundle. The Mac-specific changes to the source code have been redone to
 minimize impact (for instance, there is now no need to change the way learning and tmath headers are
@@ -13,8 +13,8 @@ Camillo Lugaresi
 
 How to install
 --------------
-- Download the Torcs 1.3.1 source package from SourceForge: [torcs-1.3.1.tar.bz2][1]
-- Extract it, and put the MacTorcs folder inside the torcs-1.3.1 folder
+- Download the Torcs 1.3.5 source package from SourceForge: [torcs-1.3.5.tar.bz2][1]
+- Extract it, and put the MacTorcs folder inside the torcs-1.3.5 folder
 - Open the Torcs project
 - Build the "Apply patch" target to patch the source code for Mac support
 - Build the "Torcs.app" target to build Torcs as a Mac application
@@ -37,5 +37,5 @@ TODO
 - Save settings in the Preferences folder instead of modifying the application bundle.
 
 
-[1]: http://sourceforge.net/projects/torcs/files/all-in-one/1.3.1/torcs-1.3.1.tar.bz2/download
-[2]: http://publish.uwo.ca/~shudson2/Home/Blog/7805725A-C647-41F0-B9C2-B91E8388D4EC.html
+[1]: http://sourceforge.net/projects/torcs/files/all-in-one/1.3.5/torcs-1.3.5.tar.bz2/download
+[2]: https://github.com/camillol/MacTorcs.git

--- a/Torcs.xcodeproj/project.pbxproj
+++ b/Torcs.xcodeproj/project.pbxproj
@@ -259,23 +259,10 @@
 		1362E75311AE7E2700AF3D9A /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC8D0DADBCE800FE87DD /* libpng.framework */; };
 		1362E75411AE7E2700AF3D9A /* zlib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC910DADBCF400FE87DD /* zlib.framework */; };
 		1362E75511AE7E2700AF3D9A /* plib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEAD1760DADC0C100FE87DD /* plib.framework */; };
-		1362E75A11AE7E3D00AF3D9A /* pit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E36711AE7D5C00AF3D9A /* pit.cpp */; };
-		1362E75B11AE7E3D00AF3D9A /* spline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E36911AE7D5C00AF3D9A /* spline.cpp */; };
-		1362E75C11AE7E3D00AF3D9A /* learn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E36111AE7D5C00AF3D9A /* learn.cpp */; };
-		1362E75D11AE7E3D00AF3D9A /* strategy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E36B11AE7D5C00AF3D9A /* strategy.cpp */; };
-		1362E75E11AE7E3D00AF3D9A /* driver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E35F11AE7D5C00AF3D9A /* driver.cpp */; };
-		1362E75F11AE7E3D00AF3D9A /* damned.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E35B11AE7D5C00AF3D9A /* damned.cpp */; };
-		1362E76011AE7E3D00AF3D9A /* opponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E36511AE7D5C00AF3D9A /* opponent.cpp */; };
-		1362E76111AE7E3D00AF3D9A /* cardata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E35911AE7D5C00AF3D9A /* cardata.cpp */; };
 		1362E77311AE7E4A00AF3D9A /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
 		1362E77411AE7E4A00AF3D9A /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC8D0DADBCE800FE87DD /* libpng.framework */; };
 		1362E77511AE7E4A00AF3D9A /* zlib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC910DADBCF400FE87DD /* zlib.framework */; };
 		1362E77611AE7E4A00AF3D9A /* plib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEAD1760DADC0C100FE87DD /* plib.framework */; };
-		1362E77B11AE7E5C00AF3D9A /* mycar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E3AD11AE7D5C00AF3D9A /* mycar.cpp */; };
-		1362E77C11AE7E5C00AF3D9A /* spline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E3B211AE7D5C00AF3D9A /* spline.cpp */; };
-		1362E77D11AE7E5C00AF3D9A /* trackdesc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E3B411AE7D5C00AF3D9A /* trackdesc.cpp */; };
-		1362E77E11AE7E5C00AF3D9A /* pathfinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E3AF11AE7D5C00AF3D9A /* pathfinder.cpp */; };
-		1362E77F11AE7E5C00AF3D9A /* inferno.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E3A711AE7D5C00AF3D9A /* inferno.cpp */; };
 		1362E78B11AE7E6200AF3D9A /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
 		1362E78C11AE7E6200AF3D9A /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC8D0DADBCE800FE87DD /* libpng.framework */; };
 		1362E78D11AE7E6200AF3D9A /* zlib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC910DADBCF400FE87DD /* zlib.framework */; };
@@ -286,11 +273,6 @@
 		1362E7B311AE7EB600AF3D9A /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC8D0DADBCE800FE87DD /* libpng.framework */; };
 		1362E7B411AE7EB600AF3D9A /* zlib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC910DADBCF400FE87DD /* zlib.framework */; };
 		1362E7B511AE7EB600AF3D9A /* plib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEAD1760DADC0C100FE87DD /* plib.framework */; };
-		1362E7BA11AE7ECA00AF3D9A /* mycar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E41511AE7D5C00AF3D9A /* mycar.cpp */; };
-		1362E7BB11AE7ECA00AF3D9A /* spline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E41A11AE7D5C00AF3D9A /* spline.cpp */; };
-		1362E7BC11AE7ECA00AF3D9A /* pathfinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E41711AE7D5C00AF3D9A /* pathfinder.cpp */; };
-		1362E7BD11AE7ECA00AF3D9A /* trackdesc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E41C11AE7D5C00AF3D9A /* trackdesc.cpp */; };
-		1362E7BE11AE7ECA00AF3D9A /* lliaw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E40F11AE7D5C00AF3D9A /* lliaw.cpp */; };
 		1362E7CA11AE7ED600AF3D9A /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
 		1362E7CB11AE7ED600AF3D9A /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC8D0DADBCE800FE87DD /* libpng.framework */; };
 		1362E7CC11AE7ED600AF3D9A /* zlib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC910DADBCF400FE87DD /* zlib.framework */; };
@@ -319,11 +301,6 @@
 		1362E81511AE7F6800AF3D9A /* libpng.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC8D0DADBCE800FE87DD /* libpng.framework */; };
 		1362E81611AE7F6800AF3D9A /* zlib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEABC910DADBCF400FE87DD /* zlib.framework */; };
 		1362E81711AE7F6800AF3D9A /* plib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEAD1760DADC0C100FE87DD /* plib.framework */; };
-		1362E82911AE7FAD00AF3D9A /* tita.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E4A911AE7D5D00AF3D9A /* tita.cpp */; };
-		1362E82A11AE7FAD00AF3D9A /* mycar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E4A211AE7D5D00AF3D9A /* mycar.cpp */; };
-		1362E82B11AE7FAD00AF3D9A /* spline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E4A711AE7D5D00AF3D9A /* spline.cpp */; };
-		1362E82C11AE7FAD00AF3D9A /* pathfinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E4A411AE7D5D00AF3D9A /* pathfinder.cpp */; };
-		1362E82D11AE7FAD00AF3D9A /* trackdesc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1362E4AD11AE7D5D00AF3D9A /* trackdesc.cpp */; };
 		1362F7CB11AEE78000AF3D9A /* rttelem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEACF960DADBF2400FE87DD /* rttelem.cpp */; };
 		1362F7CD11AEE79800AF3D9A /* Distribution.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEACF570DADBF2200FE87DD /* Distribution.cpp */; };
 		1362F7CE11AEE79800AF3D9A /* policy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEACF610DADBF2300FE87DD /* policy.cpp */; };
@@ -491,6 +468,74 @@
 		13FFB03311B0952900DFC073 /* v3_t.h in Headers */ = {isa = PBXBuildFile; fileRef = 13FFB02411B0952900DFC073 /* v3_t.h */; };
 		13FFB03411B0952900DFC073 /* v4_t.h in Headers */ = {isa = PBXBuildFile; fileRef = 13FFB02511B0952900DFC073 /* v4_t.h */; };
 		13FFB05A11B096C300DFC073 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F7CE6BA0EB7FE400081FD35 /* CoreFoundation.framework */; };
+		FC53B493189FDF9900F96E81 /* common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB533EA189FB8C3007E6151 /* common.cpp */; };
+		FC53B494189FDF9900F96E81 /* cylos1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB533EC189FB8C3007E6151 /* cylos1.cpp */; };
+		FC53B495189FF12100F96E81 /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
+		FC53B49E189FF69500F96E81 /* K1999.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB53445189FB8C3007E6151 /* K1999.cpp */; };
+		FC53B4A7189FF71100F96E81 /* common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB533FE189FB8C3007E6151 /* common.cpp */; };
+		FC53B4A8189FF71100F96E81 /* cylos2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB53400189FB8C3007E6151 /* cylos2.cpp */; };
+		FC53B4A918A0055E00F96E81 /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
+		FC53B4AA18A005B000F96E81 /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
+		FC53B4B318A2557E00F96E81 /* common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB5340F189FB8C3007E6151 /* common.cpp */; };
+		FC53B4B418A2557E00F96E81 /* tanhoj.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB53413189FB8C3007E6151 /* tanhoj.cpp */; };
+		FC53B4B618A2587D00F96E81 /* libTorcs.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FE722AA0DAC7AD3008D6F50 /* libTorcs.dylib */; };
+		FCB52F64189FA8FC007E6151 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = FCB52F53189FA8FC007E6151 /* common.h */; };
+		FCB52F65189FA8FC007E6151 /* lliaw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB52F54189FA8FC007E6151 /* lliaw.cpp */; };
+		FCB52F66189FA8FC007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52F5A189FA8FC007E6151 /* Makefile */; };
+		FCB52F67189FA8FC007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52F61189FA8FC007E6151 /* Makefile */; };
+		FCB52FE2189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FA3189FAC33007E6151 /* Makefile */; };
+		FCB52FE3189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FA3189FAC33007E6151 /* Makefile */; };
+		FCB52FE4189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FA8189FAC33007E6151 /* Makefile */; };
+		FCB52FE5189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FA8189FAC33007E6151 /* Makefile */; };
+		FCB52FE6189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FAE189FAC33007E6151 /* Makefile */; };
+		FCB52FE7189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FAE189FAC33007E6151 /* Makefile */; };
+		FCB52FE8189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FB3189FAC33007E6151 /* Makefile */; };
+		FCB52FE9189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FB3189FAC33007E6151 /* Makefile */; };
+		FCB52FEA189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FB9189FAC33007E6151 /* Makefile */; };
+		FCB52FEB189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FB9189FAC33007E6151 /* Makefile */; };
+		FCB52FEC189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FC2189FAC33007E6151 /* Makefile */; };
+		FCB52FED189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FC2189FAC33007E6151 /* Makefile */; };
+		FCB52FEE189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FC8189FAC33007E6151 /* Makefile */; };
+		FCB52FEF189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FC8189FAC33007E6151 /* Makefile */; };
+		FCB52FF0189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FCD189FAC33007E6151 /* Makefile */; };
+		FCB52FF1189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FCD189FAC33007E6151 /* Makefile */; };
+		FCB52FF2189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FD3189FAC33007E6151 /* Makefile */; };
+		FCB52FF3189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FD3189FAC33007E6151 /* Makefile */; };
+		FCB52FF4189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FD9189FAC33007E6151 /* Makefile */; };
+		FCB52FF5189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FD9189FAC33007E6151 /* Makefile */; };
+		FCB52FF6189FAC33007E6151 /* damned.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FDB189FAC33007E6151 /* damned.cpp */; };
+		FCB52FF7189FAC33007E6151 /* damned.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FDB189FAC33007E6151 /* damned.cpp */; };
+		FCB52FF8189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FE1189FAC33007E6151 /* Makefile */; };
+		FCB52FF9189FAC33007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB52FE1189FAC33007E6151 /* Makefile */; };
+		FCB53212189FB00D007E6151 /* common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB531E7189FB00D007E6151 /* common.cpp */; };
+		FCB53213189FB00D007E6151 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = FCB531E8189FB00D007E6151 /* common.h */; };
+		FCB53214189FB00D007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB531EC189FB00D007E6151 /* Makefile */; };
+		FCB53215189FB00D007E6151 /* tita.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB531ED189FB00D007E6151 /* tita.cpp */; };
+		FCB53216189FB00D007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5320E189FB00D007E6151 /* Makefile */; };
+		FCB533CF189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5321C189FB037007E6151 /* Makefile */; };
+		FCB533D0189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53242189FB037007E6151 /* Makefile */; };
+		FCB533D1189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5324A189FB037007E6151 /* Makefile */; };
+		FCB533D2189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53263189FB037007E6151 /* Makefile */; };
+		FCB533D3189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5326C189FB037007E6151 /* Makefile */; };
+		FCB533D4189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5328F189FB037007E6151 /* Makefile */; };
+		FCB533D5189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53297189FB037007E6151 /* Makefile */; };
+		FCB533D6189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB532C3189FB037007E6151 /* Makefile */; };
+		FCB533D7189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB532CC189FB037007E6151 /* Makefile */; };
+		FCB533D8189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB532F2189FB038007E6151 /* Makefile */; };
+		FCB533D9189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB532FB189FB038007E6151 /* Makefile */; };
+		FCB533DA189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53314189FB038007E6151 /* Makefile */; };
+		FCB533DB189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5331B189FB038007E6151 /* Makefile */; };
+		FCB533DC189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5333E189FB038007E6151 /* Makefile */; };
+		FCB533DD189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53346189FB038007E6151 /* Makefile */; };
+		FCB533DE189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5336B189FB038007E6151 /* Makefile */; };
+		FCB533DF189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53373189FB038007E6151 /* Makefile */; };
+		FCB533E0189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB53392189FB038007E6151 /* Makefile */; };
+		FCB533E1189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB5339A189FB038007E6151 /* Makefile */; };
+		FCB533E2189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB533BF189FB038007E6151 /* Makefile */; };
+		FCB533E3189FB038007E6151 /* common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB533C5189FB038007E6151 /* common.cpp */; };
+		FCB533E4189FB038007E6151 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = FCB533C6189FB038007E6151 /* common.h */; };
+		FCB533E5189FB038007E6151 /* inferno.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCB533C7189FB038007E6151 /* inferno.cpp */; };
+		FCB533E6189FB038007E6151 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = FCB533CD189FB038007E6151 /* Makefile */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1481,50 +1526,6 @@
 		1362E33311AE7D5C00AF3D9A /* spline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spline.h; sourceTree = "<group>"; };
 		1362E33411AE7D5C00AF3D9A /* strategy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strategy.cpp; sourceTree = "<group>"; };
 		1362E33511AE7D5C00AF3D9A /* strategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strategy.h; sourceTree = "<group>"; };
-		1362E33811AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E33911AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E33B11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E33C11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E33E11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E33F11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E34111AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E34211AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E34411AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E34511AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E34711AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E34811AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E34A11AE7D5C00AF3D9A /* car5-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car5-trb1.rgb"; sourceTree = "<group>"; };
-		1362E34B11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E34C11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E34E11AE7D5C00AF3D9A /* car6-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car6-trb1.rgb"; sourceTree = "<group>"; };
-		1362E34F11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E35011AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E35211AE7D5C00AF3D9A /* car7-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car7-trb1.rgb"; sourceTree = "<group>"; };
-		1362E35311AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E35411AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E35611AE7D5C00AF3D9A /* car1-trb3.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car1-trb3.rgb"; sourceTree = "<group>"; };
-		1362E35711AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E35811AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E35911AE7D5C00AF3D9A /* cardata.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cardata.cpp; sourceTree = "<group>"; };
-		1362E35A11AE7D5C00AF3D9A /* cardata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cardata.h; sourceTree = "<group>"; };
-		1362E35B11AE7D5C00AF3D9A /* damned.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = damned.cpp; sourceTree = "<group>"; };
-		1362E35C11AE7D5C00AF3D9A /* damned.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = damned.def; sourceTree = "<group>"; };
-		1362E35D11AE7D5C00AF3D9A /* damned.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = damned.dsp; sourceTree = "<group>"; };
-		1362E35E11AE7D5C00AF3D9A /* damned.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = damned.xml; sourceTree = "<group>"; };
-		1362E35F11AE7D5C00AF3D9A /* driver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = driver.cpp; sourceTree = "<group>"; };
-		1362E36011AE7D5C00AF3D9A /* driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = driver.h; sourceTree = "<group>"; };
-		1362E36111AE7D5C00AF3D9A /* learn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = learn.cpp; sourceTree = "<group>"; };
-		1362E36211AE7D5C00AF3D9A /* learn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = learn.h; sourceTree = "<group>"; };
-		1362E36311AE7D5C00AF3D9A /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
-		1362E36411AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E36511AE7D5C00AF3D9A /* opponent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = opponent.cpp; sourceTree = "<group>"; };
-		1362E36611AE7D5C00AF3D9A /* opponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opponent.h; sourceTree = "<group>"; };
-		1362E36711AE7D5C00AF3D9A /* pit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pit.cpp; sourceTree = "<group>"; };
-		1362E36811AE7D5C00AF3D9A /* pit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pit.h; sourceTree = "<group>"; };
-		1362E36911AE7D5C00AF3D9A /* spline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spline.cpp; sourceTree = "<group>"; };
-		1362E36A11AE7D5C00AF3D9A /* spline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spline.h; sourceTree = "<group>"; };
-		1362E36B11AE7D5C00AF3D9A /* strategy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strategy.cpp; sourceTree = "<group>"; };
-		1362E36C11AE7D5C00AF3D9A /* strategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strategy.h; sourceTree = "<group>"; };
 		1362E36E11AE7D5C00AF3D9A /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
 		1362E36F11AE7D5C00AF3D9A /* human.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = human.cpp; sourceTree = "<group>"; };
 		1362E37011AE7D5C00AF3D9A /* human.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = human.def; sourceTree = "<group>"; };
@@ -1539,51 +1540,6 @@
 		1362E37B11AE7D5C00AF3D9A /* car-pw-206wrc.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-pw-206wrc.xml"; sourceTree = "<group>"; };
 		1362E37C11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
 		1362E37D11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E38011AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E38111AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E38311AE7D5C00AF3D9A /* car1-trb3.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car1-trb3.rgb"; sourceTree = "<group>"; };
-		1362E38411AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E38511AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E38711AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E38811AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E38911AE7D5C00AF3D9A /* p406.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = p406.rgb; sourceTree = "<group>"; };
-		1362E38B11AE7D5C00AF3D9A /* car1-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car1-trb1.rgb"; sourceTree = "<group>"; };
-		1362E38C11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E38D11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E38F11AE7D5C00AF3D9A /* car2-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car2-trb1.rgb"; sourceTree = "<group>"; };
-		1362E39011AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E39111AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E39311AE7D5C00AF3D9A /* car3-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car3-trb1.rgb"; sourceTree = "<group>"; };
-		1362E39411AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E39511AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E39711AE7D5C00AF3D9A /* car4-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car4-trb1.rgb"; sourceTree = "<group>"; };
-		1362E39811AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E39911AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E39B11AE7D5C00AF3D9A /* car5-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car5-trb1.rgb"; sourceTree = "<group>"; };
-		1362E39C11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E39D11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E39F11AE7D5C00AF3D9A /* car6-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car6-trb1.rgb"; sourceTree = "<group>"; };
-		1362E3A011AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3A111AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3A311AE7D5C00AF3D9A /* car7-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car7-trb1.rgb"; sourceTree = "<group>"; };
-		1362E3A411AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3A511AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3A611AE7D5C00AF3D9A /* berniw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = berniw.h; sourceTree = "<group>"; };
-		1362E3A711AE7D5C00AF3D9A /* inferno.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inferno.cpp; sourceTree = "<group>"; };
-		1362E3A811AE7D5C00AF3D9A /* inferno.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = inferno.def; sourceTree = "<group>"; };
-		1362E3A911AE7D5C00AF3D9A /* inferno.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = inferno.dsp; sourceTree = "<group>"; };
-		1362E3AA11AE7D5C00AF3D9A /* inferno.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = inferno.xml; sourceTree = "<group>"; };
-		1362E3AB11AE7D5C00AF3D9A /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
-		1362E3AC11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3AD11AE7D5C00AF3D9A /* mycar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mycar.cpp; sourceTree = "<group>"; };
-		1362E3AE11AE7D5C00AF3D9A /* mycar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mycar.h; sourceTree = "<group>"; };
-		1362E3AF11AE7D5C00AF3D9A /* pathfinder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pathfinder.cpp; sourceTree = "<group>"; };
-		1362E3B011AE7D5C00AF3D9A /* pathfinder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pathfinder.h; sourceTree = "<group>"; };
-		1362E3B111AE7D5C00AF3D9A /* readme.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = readme.html; sourceTree = "<group>"; };
-		1362E3B211AE7D5C00AF3D9A /* spline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spline.cpp; sourceTree = "<group>"; };
-		1362E3B311AE7D5C00AF3D9A /* spline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spline.h; sourceTree = "<group>"; };
-		1362E3B411AE7D5C00AF3D9A /* trackdesc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = trackdesc.cpp; sourceTree = "<group>"; };
-		1362E3B511AE7D5C00AF3D9A /* trackdesc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trackdesc.h; sourceTree = "<group>"; };
 		1362E3B811AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
 		1362E3B911AE7D5C00AF3D9A /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
 		1362E3BA11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
@@ -1623,49 +1579,6 @@
 		1362E3E511AE7D5C00AF3D9A /* inferno2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = inferno2.xml; sourceTree = "<group>"; };
 		1362E3E611AE7D5C00AF3D9A /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
 		1362E3E711AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3EA11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3EB11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3ED11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3EE11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3F011AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3F111AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3F311AE7D5C00AF3D9A /* car1-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car1-trb1.rgb"; sourceTree = "<group>"; };
-		1362E3F411AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3F511AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3F711AE7D5C00AF3D9A /* car2-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car2-trb1.rgb"; sourceTree = "<group>"; };
-		1362E3F811AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3F911AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3FB11AE7D5C00AF3D9A /* car3-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car3-trb1.rgb"; sourceTree = "<group>"; };
-		1362E3FC11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E3FD11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E3FF11AE7D5C00AF3D9A /* car4-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car4-trb1.rgb"; sourceTree = "<group>"; };
-		1362E40011AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E40111AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E40311AE7D5C00AF3D9A /* car5-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car5-trb1.rgb"; sourceTree = "<group>"; };
-		1362E40411AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E40511AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E40711AE7D5C00AF3D9A /* car6-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car6-trb1.rgb"; sourceTree = "<group>"; };
-		1362E40811AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E40911AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E40B11AE7D5C00AF3D9A /* car7-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car7-trb1.rgb"; sourceTree = "<group>"; };
-		1362E40C11AE7D5C00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E40D11AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E40E11AE7D5C00AF3D9A /* berniw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = berniw.h; sourceTree = "<group>"; };
-		1362E40F11AE7D5C00AF3D9A /* lliaw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lliaw.cpp; sourceTree = "<group>"; };
-		1362E41011AE7D5C00AF3D9A /* lliaw.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = lliaw.def; sourceTree = "<group>"; };
-		1362E41111AE7D5C00AF3D9A /* lliaw.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = lliaw.dsp; sourceTree = "<group>"; };
-		1362E41211AE7D5C00AF3D9A /* lliaw.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = lliaw.xml; sourceTree = "<group>"; };
-		1362E41311AE7D5C00AF3D9A /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
-		1362E41411AE7D5C00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E41511AE7D5C00AF3D9A /* mycar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mycar.cpp; sourceTree = "<group>"; };
-		1362E41611AE7D5C00AF3D9A /* mycar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mycar.h; sourceTree = "<group>"; };
-		1362E41711AE7D5C00AF3D9A /* pathfinder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pathfinder.cpp; sourceTree = "<group>"; };
-		1362E41811AE7D5C00AF3D9A /* pathfinder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pathfinder.h; sourceTree = "<group>"; };
-		1362E41911AE7D5C00AF3D9A /* readme.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = readme.html; sourceTree = "<group>"; };
-		1362E41A11AE7D5C00AF3D9A /* spline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spline.cpp; sourceTree = "<group>"; };
-		1362E41B11AE7D5C00AF3D9A /* spline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spline.h; sourceTree = "<group>"; };
-		1362E41C11AE7D5C00AF3D9A /* trackdesc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = trackdesc.cpp; sourceTree = "<group>"; };
-		1362E41D11AE7D5C00AF3D9A /* trackdesc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trackdesc.h; sourceTree = "<group>"; };
 		1362E41E11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
 		1362E42111AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
 		1362E42211AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
@@ -1744,49 +1657,6 @@
 		1362E47611AE7D5D00AF3D9A /* sparkle.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = sparkle.xml; sourceTree = "<group>"; };
 		1362E47711AE7D5D00AF3D9A /* spline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spline.cpp; sourceTree = "<group>"; };
 		1362E47811AE7D5D00AF3D9A /* spline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spline.h; sourceTree = "<group>"; };
-		1362E47B11AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E47C11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E47E11AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E47F11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E48111AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E48211AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E48411AE7D5D00AF3D9A /* car1-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car1-trb1.rgb"; sourceTree = "<group>"; };
-		1362E48511AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E48611AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E48811AE7D5D00AF3D9A /* car2-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car2-trb1.rgb"; sourceTree = "<group>"; };
-		1362E48911AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E48A11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E48C11AE7D5D00AF3D9A /* car3-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car3-trb1.rgb"; sourceTree = "<group>"; };
-		1362E48D11AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E48E11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E49011AE7D5D00AF3D9A /* car4-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car4-trb1.rgb"; sourceTree = "<group>"; };
-		1362E49111AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E49211AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E49411AE7D5D00AF3D9A /* car5-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car5-trb1.rgb"; sourceTree = "<group>"; };
-		1362E49511AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E49611AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E49811AE7D5D00AF3D9A /* car6-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car6-trb1.rgb"; sourceTree = "<group>"; };
-		1362E49911AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E49A11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E49C11AE7D5D00AF3D9A /* car7-trb1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "car7-trb1.rgb"; sourceTree = "<group>"; };
-		1362E49D11AE7D5D00AF3D9A /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
-		1362E49E11AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E49F11AE7D5D00AF3D9A /* berniw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = berniw.h; sourceTree = "<group>"; };
-		1362E4A011AE7D5D00AF3D9A /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
-		1362E4A111AE7D5D00AF3D9A /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		1362E4A211AE7D5D00AF3D9A /* mycar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mycar.cpp; sourceTree = "<group>"; };
-		1362E4A311AE7D5D00AF3D9A /* mycar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mycar.h; sourceTree = "<group>"; };
-		1362E4A411AE7D5D00AF3D9A /* pathfinder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pathfinder.cpp; sourceTree = "<group>"; };
-		1362E4A511AE7D5D00AF3D9A /* pathfinder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pathfinder.h; sourceTree = "<group>"; };
-		1362E4A611AE7D5D00AF3D9A /* readme.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = readme.html; sourceTree = "<group>"; };
-		1362E4A711AE7D5D00AF3D9A /* spline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spline.cpp; sourceTree = "<group>"; };
-		1362E4A811AE7D5D00AF3D9A /* spline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spline.h; sourceTree = "<group>"; };
-		1362E4A911AE7D5D00AF3D9A /* tita.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tita.cpp; sourceTree = "<group>"; };
-		1362E4AA11AE7D5D00AF3D9A /* tita.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tita.def; sourceTree = "<group>"; };
-		1362E4AB11AE7D5D00AF3D9A /* tita.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tita.dsp; sourceTree = "<group>"; };
-		1362E4AC11AE7D5D00AF3D9A /* tita.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = tita.xml; sourceTree = "<group>"; };
-		1362E4AD11AE7D5D00AF3D9A /* trackdesc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = trackdesc.cpp; sourceTree = "<group>"; };
-		1362E4AE11AE7D5D00AF3D9A /* trackdesc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trackdesc.h; sourceTree = "<group>"; };
 		1362E6EC11AE7D9100AF3D9A /* berniw2.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = berniw2.so; sourceTree = BUILT_PRODUCTS_DIR; };
 		1362E70711AE7DB300AF3D9A /* berniw3.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = berniw3.so; sourceTree = BUILT_PRODUCTS_DIR; };
 		1362E72211AE7DD600AF3D9A /* bt.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = bt.so; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1824,6 +1694,643 @@
 		13FFB04F11B0964200DFC073 /* mac_setup_resources.mk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mac_setup_resources.mk; sourceTree = "<group>"; };
 		13FFB05011B0964200DFC073 /* torcs-1.3.1-mac.diff */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "torcs-1.3.1-mac.diff"; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Torcs.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Torcs.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC53B48F189FDEF400F96E81 /* cylos1.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = cylos1.so; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC53B49A189FF67100F96E81 /* K1999.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = K1999.so; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC53B4A3189FF6ED00F96E81 /* cylos2.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = cylos2.so; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC53B4AF18A2548600F96E81 /* tanhoj.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = tanhoj.so; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCB52F4C189FA8FC007E6151 /* logo.rgb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52F4D189FA8FC007E6151 /* viper-gts-r.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "viper-gts-r.rgb"; sourceTree = "<group>"; };
+		FCB52F4E189FA8FC007E6151 /* car-nascar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-nascar.xml"; sourceTree = "<group>"; };
+		FCB52F4F189FA8FC007E6151 /* car-torcs.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-torcs.xml"; sourceTree = "<group>"; };
+		FCB52F50189FA8FC007E6151 /* car-viper.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-viper.xml"; sourceTree = "<group>"; };
+		FCB52F51189FA8FC007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52F52189FA8FC007E6151 /* common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = common.cpp; sourceTree = "<group>"; };
+		FCB52F53189FA8FC007E6151 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		FCB52F54189FA8FC007E6151 /* lliaw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lliaw.cpp; sourceTree = "<group>"; };
+		FCB52F55189FA8FC007E6151 /* lliaw.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = lliaw.def; sourceTree = "<group>"; };
+		FCB52F56189FA8FC007E6151 /* lliaw.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = lliaw.dsp; sourceTree = "<group>"; };
+		FCB52F57189FA8FC007E6151 /* lliaw.vcproj */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = lliaw.vcproj; sourceTree = "<group>"; };
+		FCB52F58189FA8FC007E6151 /* lliaw.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = lliaw.xml; sourceTree = "<group>"; };
+		FCB52F59189FA8FC007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52F5A189FA8FC007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52F5C189FA8FC007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB52F5D189FA8FC007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB52F5E189FA8FC007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB52F5F189FA8FC007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB52F60189FA8FC007E6151 /* car_g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-3.xml"; sourceTree = "<group>"; };
+		FCB52F61189FA8FC007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52F62189FA8FC007E6151 /* viper-gts-r.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "viper-gts-r.rgb"; sourceTree = "<group>"; };
+		FCB52F9F189FAC33007E6151 /* buggy.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = buggy.rgb; sourceTree = "<group>"; };
+		FCB52FA0189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FA1189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FA2189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FA3189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FA5189FAC33007E6151 /* 155-DTM.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "155-DTM.rgb"; sourceTree = "<group>"; };
+		FCB52FA6189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FA7189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FA8189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FAA189FAC33007E6151 /* buggy.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = buggy.rgb; sourceTree = "<group>"; };
+		FCB52FAB189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FAC189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FAD189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FAE189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FB0189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FB1189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FB2189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FB3189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FB4189FAC33007E6151 /* p406.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = p406.rgb; sourceTree = "<group>"; };
+		FCB52FB6189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FB7189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FB8189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FB9189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FBA189FAC33007E6151 /* p406.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = p406.rgb; sourceTree = "<group>"; };
+		FCB52FBB189FAC33007E6151 /* torcs.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = torcs.rgb; sourceTree = "<group>"; };
+		FCB52FBD189FAC33007E6151 /* acura-nsx-sz-512.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "acura-nsx-sz-512.rgb"; sourceTree = "<group>"; };
+		FCB52FBE189FAC33007E6151 /* acura-nsx-sz.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "acura-nsx-sz.rgb"; sourceTree = "<group>"; };
+		FCB52FBF189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FC0189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FC1189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FC2189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FC4189FAC33007E6151 /* acura-nsx-sz.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "acura-nsx-sz.rgb"; sourceTree = "<group>"; };
+		FCB52FC5189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FC6189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FC7189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FC8189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FCA189FAC33007E6151 /* car-dirt.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car-dirt.xml"; sourceTree = "<group>"; };
+		FCB52FCB189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FCC189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FCD189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FCE189FAC33007E6151 /* porsche-gt1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "porsche-gt1.rgb"; sourceTree = "<group>"; };
+		FCB52FCF189FAC33007E6151 /* viper-gts-r.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "viper-gts-r.rgb"; sourceTree = "<group>"; };
+		FCB52FD1189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FD2189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FD3189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FD4189FAC33007E6151 /* mclaren-f1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "mclaren-f1.rgb"; sourceTree = "<group>"; };
+		FCB52FD6189FAC33007E6151 /* 360-modena.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "360-modena.rgb"; sourceTree = "<group>"; };
+		FCB52FD7189FAC33007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB52FD8189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FD9189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB52FDA189FAC33007E6151 /* car1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car1.xml; sourceTree = "<group>"; };
+		FCB52FDB189FAC33007E6151 /* damned.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = damned.cpp; sourceTree = "<group>"; };
+		FCB52FDC189FAC33007E6151 /* damned.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = damned.def; sourceTree = "<group>"; };
+		FCB52FDD189FAC33007E6151 /* damned.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = damned.dsp; sourceTree = "<group>"; };
+		FCB52FDE189FAC33007E6151 /* damned.vcproj */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = damned.vcproj; sourceTree = "<group>"; };
+		FCB52FDF189FAC33007E6151 /* damned.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = damned.xml; sourceTree = "<group>"; };
+		FCB52FE0189FAC33007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB52FE1189FAC33007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB531E4189FB00D007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB531E5189FB00D007E6151 /* lotus-gt1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "lotus-gt1.rgb"; sourceTree = "<group>"; };
+		FCB531E6189FB00D007E6151 /* car.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car.xml; sourceTree = "<group>"; };
+		FCB531E7189FB00D007E6151 /* common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = common.cpp; sourceTree = "<group>"; };
+		FCB531E8189FB00D007E6151 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		FCB531E9189FB00D007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB531EA189FB00D007E6151 /* lotus-gt1-512.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "lotus-gt1-512.rgb"; sourceTree = "<group>"; };
+		FCB531EB189FB00D007E6151 /* lotus-gt1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "lotus-gt1.rgb"; sourceTree = "<group>"; };
+		FCB531EC189FB00D007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB531ED189FB00D007E6151 /* tita.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tita.cpp; sourceTree = "<group>"; };
+		FCB531EE189FB00D007E6151 /* tita.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tita.def; sourceTree = "<group>"; };
+		FCB531EF189FB00D007E6151 /* tita.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tita.dsp; sourceTree = "<group>"; };
+		FCB531F0189FB00D007E6151 /* tita.vcproj */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = tita.vcproj; sourceTree = "<group>"; };
+		FCB531F1189FB00D007E6151 /* tita.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = tita.xml; sourceTree = "<group>"; };
+		FCB531F3189FB00D007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB531F4189FB00D007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB531F5189FB00D007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB531F6189FB00D007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB531F7189FB00D007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB531F8189FB00D007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB531F9189FB00D007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB531FA189FB00D007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB531FB189FB00D007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB531FC189FB00D007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB531FD189FB00D007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB531FE189FB00D007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB531FF189FB00D007E6151 /* car_g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-3.xml"; sourceTree = "<group>"; };
+		FCB53200189FB00D007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB53201189FB00D007E6151 /* car_s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_s2.xml; sourceTree = "<group>"; };
+		FCB53202189FB00D007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB53203189FB00D007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53204189FB00D007E6151 /* city-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "city-1.xml"; sourceTree = "<group>"; };
+		FCB53205189FB00D007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53206189FB00D007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53207189FB00D007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53208189FB00D007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53209189FB00D007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB5320A189FB00D007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5320B189FB00D007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB5320C189FB00D007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5320D189FB00D007E6151 /* g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-3.xml"; sourceTree = "<group>"; };
+		FCB5320E189FB00D007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5320F189FB00D007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53210189FB00D007E6151 /* s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = s2.xml; sourceTree = "<group>"; };
+		FCB53211189FB00D007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53219189FB037007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB5321A189FB037007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB5321B189FB037007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5321C189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5321D189FB037007E6151 /* mclaren-f1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "mclaren-f1.rgb"; sourceTree = "<group>"; };
+		FCB5321F189FB037007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB53220189FB037007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB53221189FB037007E6151 /* alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "alpine-1.xml"; sourceTree = "<group>"; };
+		FCB53222189FB037007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB53223189FB037007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB53224189FB037007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB53225189FB037007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB53226189FB037007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53227189FB037007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53228189FB037007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53229189FB037007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB5322A189FB037007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB5322B189FB037007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5322C189FB037007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB5322D189FB037007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB5322E189FB037007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5322F189FB037007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53230189FB037007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB53231189FB037007E6151 /* car_s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_s2.xml; sourceTree = "<group>"; };
+		FCB53232189FB037007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB53233189FB037007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53234189FB037007E6151 /* city-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "city-1.xml"; sourceTree = "<group>"; };
+		FCB53235189FB037007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53236189FB037007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53237189FB037007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53238189FB037007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53239189FB037007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB5323A189FB037007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB5323B189FB037007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB5323C189FB037007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5323D189FB037007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB5323E189FB037007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB5323F189FB037007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53240189FB037007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53241189FB037007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53242189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53243189FB037007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53244189FB037007E6151 /* s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = s2.xml; sourceTree = "<group>"; };
+		FCB53245189FB037007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53247189FB037007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB53248189FB037007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB53249189FB037007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5324A189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5324C189FB037007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5324D189FB037007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB5324E189FB037007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB5324F189FB037007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB53250189FB037007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53251189FB037007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53252189FB037007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53253189FB037007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53254189FB037007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53255189FB037007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53256189FB037007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53257189FB037007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53258189FB037007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53259189FB037007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB5325A189FB037007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB5325B189FB037007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB5325C189FB037007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB5325D189FB037007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5325E189FB037007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB5325F189FB037007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB53260189FB037007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53261189FB037007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53262189FB037007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53263189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53264189FB037007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53265189FB037007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53266189FB037007E6151 /* vm-x4.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "vm-x4.rgb"; sourceTree = "<group>"; };
+		FCB53268189FB037007E6151 /* 360-modena.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "360-modena.rgb"; sourceTree = "<group>"; };
+		FCB53269189FB037007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB5326A189FB037007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB5326B189FB037007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5326C189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5326E189FB037007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5326F189FB037007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB53270189FB037007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB53271189FB037007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB53272189FB037007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB53273189FB037007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB53274189FB037007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53275189FB037007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53276189FB037007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53277189FB037007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53278189FB037007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53279189FB037007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5327A189FB037007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB5327B189FB037007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB5327C189FB037007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5327D189FB037007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB5327E189FB037007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB5327F189FB037007E6151 /* car_s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_s2.xml; sourceTree = "<group>"; };
+		FCB53280189FB037007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB53281189FB037007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53282189FB037007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53283189FB037007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53284189FB037007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53285189FB037007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53286189FB037007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53287189FB037007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53288189FB037007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53289189FB037007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5328A189FB037007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB5328B189FB037007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB5328C189FB037007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB5328D189FB037007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5328E189FB037007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB5328F189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53290189FB037007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53291189FB037007E6151 /* s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = s2.xml; sourceTree = "<group>"; };
+		FCB53292189FB037007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53294189FB037007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB53295189FB037007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB53296189FB037007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB53297189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53298189FB037007E6151 /* porsche-gt1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "porsche-gt1.rgb"; sourceTree = "<group>"; };
+		FCB5329A189FB037007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5329B189FB037007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB5329C189FB037007E6151 /* alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "alpine-1.xml"; sourceTree = "<group>"; };
+		FCB5329D189FB037007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB5329E189FB037007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB5329F189FB037007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB532A0189FB037007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB532A1189FB037007E6151 /* car_alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_alpine-1.xml"; sourceTree = "<group>"; };
+		FCB532A2189FB037007E6151 /* car_b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_b-speedway.xml"; sourceTree = "<group>"; };
+		FCB532A3189FB037007E6151 /* car_c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_c-speedway.xml"; sourceTree = "<group>"; };
+		FCB532A4189FB037007E6151 /* car_d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_d-speedway.xml"; sourceTree = "<group>"; };
+		FCB532A5189FB037007E6151 /* car_e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-speedway.xml"; sourceTree = "<group>"; };
+		FCB532A6189FB037007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB532A7189FB037007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB532A8189FB037007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB532A9189FB037007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB532AA189FB037007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB532AB189FB037007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB532AC189FB037007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB532AD189FB037007E6151 /* car_f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_f-speedway.xml"; sourceTree = "<group>"; };
+		FCB532AE189FB037007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB532AF189FB037007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB532B0189FB037007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB532B1189FB037007E6151 /* car_h-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_h-speedway.xml"; sourceTree = "<group>"; };
+		FCB532B2189FB037007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB532B3189FB037007E6151 /* car_spring.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_spring.xml; sourceTree = "<group>"; };
+		FCB532B4189FB037007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB532B5189FB037007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB532B6189FB037007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB532B7189FB037007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB532B8189FB037007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB532B9189FB037007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB532BA189FB037007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB532BB189FB037007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB532BC189FB037007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB532BD189FB037007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB532BE189FB037007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB532BF189FB037007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB532C0189FB037007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB532C1189FB037007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB532C2189FB037007E6151 /* h-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "h-speedway.xml"; sourceTree = "<group>"; };
+		FCB532C3189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB532C4189FB037007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB532C5189FB037007E6151 /* spring.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = spring.xml; sourceTree = "<group>"; };
+		FCB532C6189FB037007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB532C8189FB037007E6151 /* clkdtm.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = clkdtm.rgb; sourceTree = "<group>"; };
+		FCB532C9189FB037007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB532CA189FB037007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB532CB189FB037007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB532CC189FB037007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB532CE189FB037007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB532CF189FB037007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB532D0189FB037007E6151 /* alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "alpine-1.xml"; sourceTree = "<group>"; };
+		FCB532D1189FB037007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB532D2189FB037007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB532D3189FB037007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB532D4189FB037007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB532D5189FB037007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB532D6189FB037007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB532D7189FB037007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB532D8189FB037007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB532D9189FB037007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB532DA189FB037007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB532DB189FB037007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB532DC189FB037007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB532DD189FB037007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB532DE189FB037007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB532DF189FB037007E6151 /* car_g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-3.xml"; sourceTree = "<group>"; };
+		FCB532E0189FB037007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB532E1189FB037007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB532E2189FB037007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB532E3189FB037007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB532E4189FB037007E6151 /* dirt-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "dirt-2.xml"; sourceTree = "<group>"; };
+		FCB532E5189FB037007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB532E6189FB037007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB532E7189FB037007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB532E8189FB037007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB532E9189FB037007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB532EA189FB037007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB532EB189FB037007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB532EC189FB037007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB532ED189FB038007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB532EE189FB038007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB532EF189FB038007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB532F0189FB038007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB532F1189FB038007E6151 /* g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-3.xml"; sourceTree = "<group>"; };
+		FCB532F2189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB532F3189FB038007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB532F4189FB038007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB532F5189FB038007E6151 /* wheel3d.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wheel3d.png; sourceTree = "<group>"; };
+		FCB532F7189FB038007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB532F8189FB038007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB532F9189FB038007E6151 /* gt40.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = gt40.rgb; sourceTree = "<group>"; };
+		FCB532FA189FB038007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB532FB189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB532FD189FB038007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB532FE189FB038007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB532FF189FB038007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB53300189FB038007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB53301189FB038007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53302189FB038007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53303189FB038007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53304189FB038007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53305189FB038007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53306189FB038007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53307189FB038007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53308189FB038007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53309189FB038007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB5330A189FB038007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB5330B189FB038007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB5330C189FB038007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB5330D189FB038007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB5330E189FB038007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5330F189FB038007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB53310189FB038007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB53311189FB038007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53312189FB038007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53313189FB038007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53314189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53315189FB038007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53316189FB038007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53318189FB038007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB53319189FB038007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB5331A189FB038007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5331B189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5331C189FB038007E6151 /* porsche-gt3rs.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "porsche-gt3rs.rgb"; sourceTree = "<group>"; };
+		FCB5331E189FB038007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5331F189FB038007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB53320189FB038007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB53321189FB038007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB53322189FB038007E6151 /* car_b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_b-speedway.xml"; sourceTree = "<group>"; };
+		FCB53323189FB038007E6151 /* car_c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_c-speedway.xml"; sourceTree = "<group>"; };
+		FCB53324189FB038007E6151 /* car_d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53325189FB038007E6151 /* car_e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53326189FB038007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53327189FB038007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53328189FB038007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53329189FB038007E6151 /* car_f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_f-speedway.xml"; sourceTree = "<group>"; };
+		FCB5332A189FB038007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB5332B189FB038007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5332C189FB038007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB5332D189FB038007E6151 /* car_g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-3.xml"; sourceTree = "<group>"; };
+		FCB5332E189FB038007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB5332F189FB038007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53330189FB038007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53331189FB038007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53332189FB038007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53333189FB038007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53334189FB038007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53335189FB038007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53336189FB038007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53337189FB038007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53338189FB038007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB53339189FB038007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB5333A189FB038007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB5333B189FB038007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5333C189FB038007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB5333D189FB038007E6151 /* g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-3.xml"; sourceTree = "<group>"; };
+		FCB5333E189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5333F189FB038007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53340189FB038007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53342189FB038007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB53343189FB038007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB53344189FB038007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB53345189FB038007E6151 /* lotus-gt1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "lotus-gt1.rgb"; sourceTree = "<group>"; };
+		FCB53346189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53348189FB038007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB53349189FB038007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB5334A189FB038007E6151 /* alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "alpine-1.xml"; sourceTree = "<group>"; };
+		FCB5334B189FB038007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB5334C189FB038007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB5334D189FB038007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5334E189FB038007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB5334F189FB038007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53350189FB038007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53351189FB038007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53352189FB038007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53353189FB038007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53354189FB038007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53355189FB038007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB53356189FB038007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53357189FB038007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53358189FB038007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53359189FB038007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB5335A189FB038007E6151 /* car_s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_s2.xml; sourceTree = "<group>"; };
+		FCB5335B189FB038007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB5335C189FB038007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB5335D189FB038007E6151 /* city-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "city-1.xml"; sourceTree = "<group>"; };
+		FCB5335E189FB038007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB5335F189FB038007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53360189FB038007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53361189FB038007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53362189FB038007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53363189FB038007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53364189FB038007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53365189FB038007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53366189FB038007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB53367189FB038007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB53368189FB038007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB53369189FB038007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB5336A189FB038007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB5336B189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5336C189FB038007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB5336D189FB038007E6151 /* s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = s2.xml; sourceTree = "<group>"; };
+		FCB5336E189FB038007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53370189FB038007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB53371189FB038007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB53372189FB038007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB53373189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53374189FB038007E6151 /* p406.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = p406.rgb; sourceTree = "<group>"; };
+		FCB53376189FB038007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB53377189FB038007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB53378189FB038007E6151 /* alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "alpine-1.xml"; sourceTree = "<group>"; };
+		FCB53379189FB038007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB5337A189FB038007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB5337B189FB038007E6151 /* car_dirt-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_dirt-1.xml"; sourceTree = "<group>"; };
+		FCB5337C189FB038007E6151 /* car_dirt-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_dirt-2.xml"; sourceTree = "<group>"; };
+		FCB5337D189FB038007E6151 /* car_dirt-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_dirt-3.xml"; sourceTree = "<group>"; };
+		FCB5337E189FB038007E6151 /* car_dirt-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_dirt-4.xml"; sourceTree = "<group>"; };
+		FCB5337F189FB038007E6151 /* car_dirt-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_dirt-5.xml"; sourceTree = "<group>"; };
+		FCB53380189FB038007E6151 /* car_dirt-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_dirt-6.xml"; sourceTree = "<group>"; };
+		FCB53381189FB038007E6151 /* car_g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-3.xml"; sourceTree = "<group>"; };
+		FCB53382189FB038007E6151 /* car_mixed-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_mixed-1.xml"; sourceTree = "<group>"; };
+		FCB53383189FB038007E6151 /* car_mixed-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_mixed-2.xml"; sourceTree = "<group>"; };
+		FCB53384189FB038007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB53385189FB038007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB53386189FB038007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB53387189FB038007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB53388189FB038007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53389189FB038007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB5338A189FB038007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB5338B189FB038007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB5338C189FB038007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB5338D189FB038007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB5338E189FB038007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB5338F189FB038007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53390189FB038007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB53391189FB038007E6151 /* g-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-3.xml"; sourceTree = "<group>"; };
+		FCB53392189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53393189FB038007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53394189FB038007E6151 /* spring.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = spring.xml; sourceTree = "<group>"; };
+		FCB53395189FB038007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB53397189FB038007E6151 /* default.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = default.xml; sourceTree = "<group>"; };
+		FCB53398189FB038007E6151 /* defaultcar.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = defaultcar.xml; sourceTree = "<group>"; };
+		FCB53399189FB038007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5339A189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB5339C189FB038007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5339D189FB038007E6151 /* aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB5339E189FB038007E6151 /* alpine-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "alpine-1.xml"; sourceTree = "<group>"; };
+		FCB5339F189FB038007E6151 /* b-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "b-speedway.xml"; sourceTree = "<group>"; };
+		FCB533A0189FB038007E6151 /* c-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "c-speedway.xml"; sourceTree = "<group>"; };
+		FCB533A1189FB038007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB533A2189FB038007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB533A3189FB038007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB533A4189FB038007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB533A5189FB038007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB533A6189FB038007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB533A7189FB038007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB533A8189FB038007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB533A9189FB038007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB533AA189FB038007E6151 /* car_g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-speedway.xml"; sourceTree = "<group>"; };
+		FCB533AB189FB038007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB533AC189FB038007E6151 /* car_g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_g-track-2.xml"; sourceTree = "<group>"; };
+		FCB533AD189FB038007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB533AE189FB038007E6151 /* car_s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car_s2.xml; sourceTree = "<group>"; };
+		FCB533AF189FB038007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB533B0189FB038007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB533B1189FB038007E6151 /* city-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "city-1.xml"; sourceTree = "<group>"; };
+		FCB533B2189FB038007E6151 /* d-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "d-speedway.xml"; sourceTree = "<group>"; };
+		FCB533B3189FB038007E6151 /* e-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-speedway.xml"; sourceTree = "<group>"; };
+		FCB533B4189FB038007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB533B5189FB038007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB533B6189FB038007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB533B7189FB038007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB533B8189FB038007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB533B9189FB038007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB533BA189FB038007E6151 /* eroad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB533BB189FB038007E6151 /* f-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "f-speedway.xml"; sourceTree = "<group>"; };
+		FCB533BC189FB038007E6151 /* g-speedway.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-speedway.xml"; sourceTree = "<group>"; };
+		FCB533BD189FB038007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB533BE189FB038007E6151 /* g-track-2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "g-track-2.xml"; sourceTree = "<group>"; };
+		FCB533BF189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB533C0189FB038007E6151 /* michigan.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB533C1189FB038007E6151 /* s2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = s2.xml; sourceTree = "<group>"; };
+		FCB533C2189FB038007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB533C3189FB038007E6151 /* vm-x2.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "vm-x2.rgb"; sourceTree = "<group>"; };
+		FCB533C4189FB038007E6151 /* car1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = car1.xml; sourceTree = "<group>"; };
+		FCB533C5189FB038007E6151 /* common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = common.cpp; sourceTree = "<group>"; };
+		FCB533C6189FB038007E6151 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		FCB533C7189FB038007E6151 /* inferno.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inferno.cpp; sourceTree = "<group>"; };
+		FCB533C8189FB038007E6151 /* inferno.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = inferno.def; sourceTree = "<group>"; };
+		FCB533C9189FB038007E6151 /* inferno.dsp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = inferno.dsp; sourceTree = "<group>"; };
+		FCB533CA189FB038007E6151 /* inferno.vcproj */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = inferno.vcproj; sourceTree = "<group>"; };
+		FCB533CB189FB038007E6151 /* inferno.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = inferno.xml; sourceTree = "<group>"; };
+		FCB533CC189FB038007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB533CD189FB038007E6151 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB533CE189FB038007E6151 /* mclaren-f1.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "mclaren-f1.rgb"; sourceTree = "<group>"; };
+		FCB533E8189FB8C3007E6151 /* car1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car1.xml; sourceTree = "<group>"; };
+		FCB533E9189FB8C3007E6151 /* cg-nascar-rwd.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cg-nascar-rwd.rgb"; sourceTree = "<group>"; };
+		FCB533EA189FB8C3007E6151 /* common.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = common.cpp; sourceTree = "<group>"; };
+		FCB533EB189FB8C3007E6151 /* common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		FCB533EC189FB8C3007E6151 /* cylos1.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cylos1.cpp; sourceTree = "<group>"; };
+		FCB533ED189FB8C3007E6151 /* cylos1.def */ = {isa = PBXFileReference; lastKnownFileType = text; path = cylos1.def; sourceTree = "<group>"; };
+		FCB533EE189FB8C3007E6151 /* cylos1.dsp */ = {isa = PBXFileReference; lastKnownFileType = text; path = cylos1.dsp; sourceTree = "<group>"; };
+		FCB533EF189FB8C3007E6151 /* cylos1.vcproj */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = cylos1.vcproj; sourceTree = "<group>"; };
+		FCB533F0189FB8C3007E6151 /* cylos1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = cylos1.xml; sourceTree = "<group>"; };
+		FCB533F1189FB8C3007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB533F2189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB533F3189FB8C3007E6151 /* mkdepend */ = {isa = PBXFileReference; lastKnownFileType = text; path = mkdepend; sourceTree = "<group>"; };
+		FCB533F5189FB8C3007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB533F6189FB8C3007E6151 /* car_lemans.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car_lemans.xml; sourceTree = "<group>"; };
+		FCB533F7189FB8C3007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB533F8189FB8C3007E6151 /* lemans.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = lemans.xml; sourceTree = "<group>"; };
+		FCB533F9189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB533FA189FB8C3007E6151 /* michigan.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB533FC189FB8C3007E6151 /* car1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car1.xml; sourceTree = "<group>"; };
+		FCB533FD189FB8C3007E6151 /* cg-nascar-rwd.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cg-nascar-rwd.rgb"; sourceTree = "<group>"; };
+		FCB533FE189FB8C3007E6151 /* common.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = common.cpp; sourceTree = "<group>"; };
+		FCB533FF189FB8C3007E6151 /* common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		FCB53400189FB8C3007E6151 /* cylos2.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cylos2.cpp; sourceTree = "<group>"; };
+		FCB53401189FB8C3007E6151 /* cylos2.def */ = {isa = PBXFileReference; lastKnownFileType = text; path = cylos2.def; sourceTree = "<group>"; };
+		FCB53402189FB8C3007E6151 /* cylos2.dsp */ = {isa = PBXFileReference; lastKnownFileType = text; path = cylos2.dsp; sourceTree = "<group>"; };
+		FCB53403189FB8C3007E6151 /* cylos2.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = cylos2.xml; sourceTree = "<group>"; };
+		FCB53404189FB8C3007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB53405189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53407189FB8C3007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53408189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53409189FB8C3007E6151 /* michigan.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB5340C189FB8C3007E6151 /* cg-nascar-rwd.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cg-nascar-rwd.rgb"; sourceTree = "<group>"; };
+		FCB5340D189FB8C3007E6151 /* car1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car1.xml; sourceTree = "<group>"; };
+		FCB5340E189FB8C3007E6151 /* cg-nascar-rwd.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cg-nascar-rwd.rgb"; sourceTree = "<group>"; };
+		FCB5340F189FB8C3007E6151 /* common.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = common.cpp; sourceTree = "<group>"; };
+		FCB53410189FB8C3007E6151 /* common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		FCB53411189FB8C3007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB53412189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53413189FB8C3007E6151 /* tanhoj.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tanhoj.cpp; sourceTree = "<group>"; };
+		FCB53414189FB8C3007E6151 /* tanhoj.def */ = {isa = PBXFileReference; lastKnownFileType = text; path = tanhoj.def; sourceTree = "<group>"; };
+		FCB53415189FB8C3007E6151 /* tanhoj.dsp */ = {isa = PBXFileReference; lastKnownFileType = text; path = tanhoj.dsp; sourceTree = "<group>"; };
+		FCB53416189FB8C3007E6151 /* tanhoj.vcproj */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = tanhoj.vcproj; sourceTree = "<group>"; };
+		FCB53417189FB8C3007E6151 /* tanhoj.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = tanhoj.xml; sourceTree = "<group>"; };
+		FCB53419189FB8C3007E6151 /* a-speedway.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5341A189FB8C3007E6151 /* aalborg.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = aalborg.xml; sourceTree = "<group>"; };
+		FCB5341B189FB8C3007E6151 /* car_a-speedway.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_a-speedway.xml"; sourceTree = "<group>"; };
+		FCB5341C189FB8C3007E6151 /* car_aalborg.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car_aalborg.xml; sourceTree = "<group>"; };
+		FCB5341D189FB8C3007E6151 /* car_e-track-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-1.xml"; sourceTree = "<group>"; };
+		FCB5341E189FB8C3007E6151 /* car_e-track-2.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-2.xml"; sourceTree = "<group>"; };
+		FCB5341F189FB8C3007E6151 /* car_e-track-3.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-3.xml"; sourceTree = "<group>"; };
+		FCB53420189FB8C3007E6151 /* car_e-track-4.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53421189FB8C3007E6151 /* car_e-track-5.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53422189FB8C3007E6151 /* car_e-track-6.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53423189FB8C3007E6151 /* car_eroad.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car_eroad.xml; sourceTree = "<group>"; };
+		FCB53424189FB8C3007E6151 /* car_g-track-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53425189FB8C3007E6151 /* car_g-track-3.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_g-track-3.xml"; sourceTree = "<group>"; };
+		FCB53426189FB8C3007E6151 /* car_michigan.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car_michigan.xml; sourceTree = "<group>"; };
+		FCB53427189FB8C3007E6151 /* car_s2.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = car_s2.xml; sourceTree = "<group>"; };
+		FCB53428189FB8C3007E6151 /* car_test-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_test-1.xml"; sourceTree = "<group>"; };
+		FCB53429189FB8C3007E6151 /* car_wheel-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "car_wheel-1.xml"; sourceTree = "<group>"; };
+		FCB5342A189FB8C3007E6151 /* city-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "city-1.xml"; sourceTree = "<group>"; };
+		FCB5342B189FB8C3007E6151 /* dirt-2.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "dirt-2.xml"; sourceTree = "<group>"; };
+		FCB5342C189FB8C3007E6151 /* e-track-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "e-track-1.xml"; sourceTree = "<group>"; };
+		FCB5342D189FB8C3007E6151 /* e-track-2.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "e-track-2.xml"; sourceTree = "<group>"; };
+		FCB5342E189FB8C3007E6151 /* e-track-3.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "e-track-3.xml"; sourceTree = "<group>"; };
+		FCB5342F189FB8C3007E6151 /* e-track-4.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "e-track-4.xml"; sourceTree = "<group>"; };
+		FCB53430189FB8C3007E6151 /* e-track-5.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "e-track-5.xml"; sourceTree = "<group>"; };
+		FCB53431189FB8C3007E6151 /* e-track-6.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "e-track-6.xml"; sourceTree = "<group>"; };
+		FCB53432189FB8C3007E6151 /* eroad.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = eroad.xml; sourceTree = "<group>"; };
+		FCB53433189FB8C3007E6151 /* g-track-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "g-track-1.xml"; sourceTree = "<group>"; };
+		FCB53434189FB8C3007E6151 /* g-track-3.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "g-track-3.xml"; sourceTree = "<group>"; };
+		FCB53435189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53436189FB8C3007E6151 /* michigan.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = michigan.xml; sourceTree = "<group>"; };
+		FCB53437189FB8C3007E6151 /* s2.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = s2.xml; sourceTree = "<group>"; };
+		FCB53438189FB8C3007E6151 /* wheel-1.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "wheel-1.xml"; sourceTree = "<group>"; };
+		FCB5343B189FB8C3007E6151 /* cg-nascar-rwd.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cg-nascar-rwd.rgb"; sourceTree = "<group>"; };
+		FCB5343C189FB8C3007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5343E189FB8C3007E6151 /* buggy.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = buggy.rgb; sourceTree = "<group>"; };
+		FCB5343F189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53440189FB8C3007E6151 /* settings.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = settings.xml; sourceTree = "<group>"; };
+		FCB53442189FB8C3007E6151 /* cg-nascar-rwd.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cg-nascar-rwd.rgb"; sourceTree = "<group>"; };
+		FCB53443189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		FCB53444189FB8C3007E6151 /* settings.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = settings.xml; sourceTree = "<group>"; };
+		FCB53445189FB8C3007E6151 /* K1999.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = K1999.cpp; sourceTree = "<group>"; };
+		FCB53446189FB8C3007E6151 /* K1999.def */ = {isa = PBXFileReference; lastKnownFileType = text; path = K1999.def; sourceTree = "<group>"; };
+		FCB53447189FB8C3007E6151 /* K1999.dsp */ = {isa = PBXFileReference; lastKnownFileType = text; path = K1999.dsp; sourceTree = "<group>"; };
+		FCB53448189FB8C3007E6151 /* K1999.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = K1999.xml; sourceTree = "<group>"; };
+		FCB53449189FB8C3007E6151 /* logo.rgb */ = {isa = PBXFileReference; lastKnownFileType = file; path = logo.rgb; sourceTree = "<group>"; };
+		FCB5344A189FB8C3007E6151 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2031,6 +2538,38 @@
 				0FD6BCA30DAF0CAD0099A426 /* plib.framework in Frameworks */,
 				0FEB49300DBEB37F00282367 /* OpenAL.framework in Frameworks */,
 				0FEB49350DBEB3B300282367 /* freealut.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B48C189FDEF400F96E81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B495189FF12100F96E81 /* libTorcs.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B497189FF67100F96E81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B4AA18A005B000F96E81 /* libTorcs.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B4A0189FF6ED00F96E81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B4A918A0055E00F96E81 /* libTorcs.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B4AC18A2548600F96E81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B4B618A2587D00F96E81 /* libTorcs.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2801,19 +3340,23 @@
 		1362E21111AE7D5B00AF3D9A /* drivers */ = {
 			isa = PBXGroup;
 			children = (
+				FCB533E7189FB8C3007E6151 /* cylos1 */,
+				FCB533FB189FB8C3007E6151 /* cylos2 */,
+				FCB5340A189FB8C3007E6151 /* tanhoj */,
+				FCB53439189FB8C3007E6151 /* K1999 */,
+				FCB53217189FB037007E6151 /* inferno */,
+				FCB531E2189FB00D007E6151 /* tita */,
+				FCB52F9D189FAC33007E6151 /* damned */,
+				FCB52F4A189FA8FC007E6151 /* lliaw */,
 				1362E21211AE7D5B00AF3D9A /* berniw */,
 				1362E27C11AE7D5B00AF3D9A /* berniw2 */,
 				1362E2B011AE7D5B00AF3D9A /* berniw3 */,
 				1362E2E011AE7D5C00AF3D9A /* bt */,
-				1362E33611AE7D5C00AF3D9A /* damned */,
 				1362E36D11AE7D5C00AF3D9A /* human */,
-				1362E37E11AE7D5C00AF3D9A /* inferno */,
 				1362E3B611AE7D5C00AF3D9A /* inferno2 */,
-				1362E3E811AE7D5C00AF3D9A /* lliaw */,
 				1362E41E11AE7D5D00AF3D9A /* Makefile */,
 				1362E41F11AE7D5D00AF3D9A /* olethros */,
 				1362E46511AE7D5D00AF3D9A /* sparkle */,
-				1362E47911AE7D5D00AF3D9A /* tita */,
 			);
 			path = drivers;
 			sourceTree = "<group>";
@@ -3456,137 +3999,6 @@
 			path = 9;
 			sourceTree = "<group>";
 		};
-		1362E33611AE7D5C00AF3D9A /* damned */ = {
-			isa = PBXGroup;
-			children = (
-				1362E33711AE7D5C00AF3D9A /* 0 */,
-				1362E33A11AE7D5C00AF3D9A /* 1 */,
-				1362E33D11AE7D5C00AF3D9A /* 2 */,
-				1362E34011AE7D5C00AF3D9A /* 3 */,
-				1362E34311AE7D5C00AF3D9A /* 4 */,
-				1362E34611AE7D5C00AF3D9A /* 5 */,
-				1362E34911AE7D5C00AF3D9A /* 6 */,
-				1362E34D11AE7D5C00AF3D9A /* 7 */,
-				1362E35111AE7D5C00AF3D9A /* 8 */,
-				1362E35511AE7D5C00AF3D9A /* 9 */,
-				1362E35911AE7D5C00AF3D9A /* cardata.cpp */,
-				1362E35A11AE7D5C00AF3D9A /* cardata.h */,
-				1362E35B11AE7D5C00AF3D9A /* damned.cpp */,
-				1362E35C11AE7D5C00AF3D9A /* damned.def */,
-				1362E35D11AE7D5C00AF3D9A /* damned.dsp */,
-				1362E35E11AE7D5C00AF3D9A /* damned.xml */,
-				1362E35F11AE7D5C00AF3D9A /* driver.cpp */,
-				1362E36011AE7D5C00AF3D9A /* driver.h */,
-				1362E36111AE7D5C00AF3D9A /* learn.cpp */,
-				1362E36211AE7D5C00AF3D9A /* learn.h */,
-				1362E36311AE7D5C00AF3D9A /* logo.rgb */,
-				1362E36411AE7D5C00AF3D9A /* Makefile */,
-				1362E36511AE7D5C00AF3D9A /* opponent.cpp */,
-				1362E36611AE7D5C00AF3D9A /* opponent.h */,
-				1362E36711AE7D5C00AF3D9A /* pit.cpp */,
-				1362E36811AE7D5C00AF3D9A /* pit.h */,
-				1362E36911AE7D5C00AF3D9A /* spline.cpp */,
-				1362E36A11AE7D5C00AF3D9A /* spline.h */,
-				1362E36B11AE7D5C00AF3D9A /* strategy.cpp */,
-				1362E36C11AE7D5C00AF3D9A /* strategy.h */,
-			);
-			path = damned;
-			sourceTree = "<group>";
-		};
-		1362E33711AE7D5C00AF3D9A /* 0 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E33811AE7D5C00AF3D9A /* default.xml */,
-				1362E33911AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 0;
-			sourceTree = "<group>";
-		};
-		1362E33A11AE7D5C00AF3D9A /* 1 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E33B11AE7D5C00AF3D9A /* default.xml */,
-				1362E33C11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 1;
-			sourceTree = "<group>";
-		};
-		1362E33D11AE7D5C00AF3D9A /* 2 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E33E11AE7D5C00AF3D9A /* default.xml */,
-				1362E33F11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 2;
-			sourceTree = "<group>";
-		};
-		1362E34011AE7D5C00AF3D9A /* 3 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E34111AE7D5C00AF3D9A /* default.xml */,
-				1362E34211AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 3;
-			sourceTree = "<group>";
-		};
-		1362E34311AE7D5C00AF3D9A /* 4 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E34411AE7D5C00AF3D9A /* default.xml */,
-				1362E34511AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 4;
-			sourceTree = "<group>";
-		};
-		1362E34611AE7D5C00AF3D9A /* 5 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E34711AE7D5C00AF3D9A /* default.xml */,
-				1362E34811AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 5;
-			sourceTree = "<group>";
-		};
-		1362E34911AE7D5C00AF3D9A /* 6 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E34A11AE7D5C00AF3D9A /* car5-trb1.rgb */,
-				1362E34B11AE7D5C00AF3D9A /* default.xml */,
-				1362E34C11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 6;
-			sourceTree = "<group>";
-		};
-		1362E34D11AE7D5C00AF3D9A /* 7 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E34E11AE7D5C00AF3D9A /* car6-trb1.rgb */,
-				1362E34F11AE7D5C00AF3D9A /* default.xml */,
-				1362E35011AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 7;
-			sourceTree = "<group>";
-		};
-		1362E35111AE7D5C00AF3D9A /* 8 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E35211AE7D5C00AF3D9A /* car7-trb1.rgb */,
-				1362E35311AE7D5C00AF3D9A /* default.xml */,
-				1362E35411AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 8;
-			sourceTree = "<group>";
-		};
-		1362E35511AE7D5C00AF3D9A /* 9 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E35611AE7D5C00AF3D9A /* car1-trb3.rgb */,
-				1362E35711AE7D5C00AF3D9A /* default.xml */,
-				1362E35811AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 9;
-			sourceTree = "<group>";
-		};
 		1362E36D11AE7D5C00AF3D9A /* human */ = {
 			isa = PBXGroup;
 			children = (
@@ -3622,138 +4034,6 @@
 				1362E37C11AE7D5C00AF3D9A /* Makefile */,
 			);
 			path = "dirt-2";
-			sourceTree = "<group>";
-		};
-		1362E37E11AE7D5C00AF3D9A /* inferno */ = {
-			isa = PBXGroup;
-			children = (
-				1362E37F11AE7D5C00AF3D9A /* 1 */,
-				1362E38211AE7D5C00AF3D9A /* 10 */,
-				1362E38611AE7D5C00AF3D9A /* 2 */,
-				1362E38A11AE7D5C00AF3D9A /* 3 */,
-				1362E38E11AE7D5C00AF3D9A /* 4 */,
-				1362E39211AE7D5C00AF3D9A /* 5 */,
-				1362E39611AE7D5C00AF3D9A /* 6 */,
-				1362E39A11AE7D5C00AF3D9A /* 7 */,
-				1362E39E11AE7D5C00AF3D9A /* 8 */,
-				1362E3A211AE7D5C00AF3D9A /* 9 */,
-				1362E3A611AE7D5C00AF3D9A /* berniw.h */,
-				1362E3A711AE7D5C00AF3D9A /* inferno.cpp */,
-				1362E3A811AE7D5C00AF3D9A /* inferno.def */,
-				1362E3A911AE7D5C00AF3D9A /* inferno.dsp */,
-				1362E3AA11AE7D5C00AF3D9A /* inferno.xml */,
-				1362E3AB11AE7D5C00AF3D9A /* logo.rgb */,
-				1362E3AC11AE7D5C00AF3D9A /* Makefile */,
-				1362E3AD11AE7D5C00AF3D9A /* mycar.cpp */,
-				1362E3AE11AE7D5C00AF3D9A /* mycar.h */,
-				1362E3AF11AE7D5C00AF3D9A /* pathfinder.cpp */,
-				1362E3B011AE7D5C00AF3D9A /* pathfinder.h */,
-				1362E3B111AE7D5C00AF3D9A /* readme.html */,
-				1362E3B211AE7D5C00AF3D9A /* spline.cpp */,
-				1362E3B311AE7D5C00AF3D9A /* spline.h */,
-				1362E3B411AE7D5C00AF3D9A /* trackdesc.cpp */,
-				1362E3B511AE7D5C00AF3D9A /* trackdesc.h */,
-			);
-			path = inferno;
-			sourceTree = "<group>";
-		};
-		1362E37F11AE7D5C00AF3D9A /* 1 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E38011AE7D5C00AF3D9A /* default.xml */,
-				1362E38111AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 1;
-			sourceTree = "<group>";
-		};
-		1362E38211AE7D5C00AF3D9A /* 10 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E38311AE7D5C00AF3D9A /* car1-trb3.rgb */,
-				1362E38411AE7D5C00AF3D9A /* default.xml */,
-				1362E38511AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 10;
-			sourceTree = "<group>";
-		};
-		1362E38611AE7D5C00AF3D9A /* 2 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E38711AE7D5C00AF3D9A /* default.xml */,
-				1362E38811AE7D5C00AF3D9A /* Makefile */,
-				1362E38911AE7D5C00AF3D9A /* p406.rgb */,
-			);
-			path = 2;
-			sourceTree = "<group>";
-		};
-		1362E38A11AE7D5C00AF3D9A /* 3 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E38B11AE7D5C00AF3D9A /* car1-trb1.rgb */,
-				1362E38C11AE7D5C00AF3D9A /* default.xml */,
-				1362E38D11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 3;
-			sourceTree = "<group>";
-		};
-		1362E38E11AE7D5C00AF3D9A /* 4 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E38F11AE7D5C00AF3D9A /* car2-trb1.rgb */,
-				1362E39011AE7D5C00AF3D9A /* default.xml */,
-				1362E39111AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 4;
-			sourceTree = "<group>";
-		};
-		1362E39211AE7D5C00AF3D9A /* 5 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E39311AE7D5C00AF3D9A /* car3-trb1.rgb */,
-				1362E39411AE7D5C00AF3D9A /* default.xml */,
-				1362E39511AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 5;
-			sourceTree = "<group>";
-		};
-		1362E39611AE7D5C00AF3D9A /* 6 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E39711AE7D5C00AF3D9A /* car4-trb1.rgb */,
-				1362E39811AE7D5C00AF3D9A /* default.xml */,
-				1362E39911AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 6;
-			sourceTree = "<group>";
-		};
-		1362E39A11AE7D5C00AF3D9A /* 7 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E39B11AE7D5C00AF3D9A /* car5-trb1.rgb */,
-				1362E39C11AE7D5C00AF3D9A /* default.xml */,
-				1362E39D11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 7;
-			sourceTree = "<group>";
-		};
-		1362E39E11AE7D5C00AF3D9A /* 8 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E39F11AE7D5C00AF3D9A /* car6-trb1.rgb */,
-				1362E3A011AE7D5C00AF3D9A /* default.xml */,
-				1362E3A111AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 8;
-			sourceTree = "<group>";
-		};
-		1362E3A211AE7D5C00AF3D9A /* 9 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3A311AE7D5C00AF3D9A /* car7-trb1.rgb */,
-				1362E3A411AE7D5C00AF3D9A /* default.xml */,
-				1362E3A511AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 9;
 			sourceTree = "<group>";
 		};
 		1362E3B611AE7D5C00AF3D9A /* inferno2 */ = {
@@ -3878,136 +4158,6 @@
 				1362E3DC11AE7D5C00AF3D9A /* default.xml */,
 				1362E3DD11AE7D5C00AF3D9A /* defaultcar.xml */,
 				1362E3DE11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 9;
-			sourceTree = "<group>";
-		};
-		1362E3E811AE7D5C00AF3D9A /* lliaw */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3E911AE7D5C00AF3D9A /* 1 */,
-				1362E3EC11AE7D5C00AF3D9A /* 10 */,
-				1362E3EF11AE7D5C00AF3D9A /* 2 */,
-				1362E3F211AE7D5C00AF3D9A /* 3 */,
-				1362E3F611AE7D5C00AF3D9A /* 4 */,
-				1362E3FA11AE7D5C00AF3D9A /* 5 */,
-				1362E3FE11AE7D5C00AF3D9A /* 6 */,
-				1362E40211AE7D5C00AF3D9A /* 7 */,
-				1362E40611AE7D5C00AF3D9A /* 8 */,
-				1362E40A11AE7D5C00AF3D9A /* 9 */,
-				1362E40E11AE7D5C00AF3D9A /* berniw.h */,
-				1362E40F11AE7D5C00AF3D9A /* lliaw.cpp */,
-				1362E41011AE7D5C00AF3D9A /* lliaw.def */,
-				1362E41111AE7D5C00AF3D9A /* lliaw.dsp */,
-				1362E41211AE7D5C00AF3D9A /* lliaw.xml */,
-				1362E41311AE7D5C00AF3D9A /* logo.rgb */,
-				1362E41411AE7D5C00AF3D9A /* Makefile */,
-				1362E41511AE7D5C00AF3D9A /* mycar.cpp */,
-				1362E41611AE7D5C00AF3D9A /* mycar.h */,
-				1362E41711AE7D5C00AF3D9A /* pathfinder.cpp */,
-				1362E41811AE7D5C00AF3D9A /* pathfinder.h */,
-				1362E41911AE7D5C00AF3D9A /* readme.html */,
-				1362E41A11AE7D5C00AF3D9A /* spline.cpp */,
-				1362E41B11AE7D5C00AF3D9A /* spline.h */,
-				1362E41C11AE7D5C00AF3D9A /* trackdesc.cpp */,
-				1362E41D11AE7D5C00AF3D9A /* trackdesc.h */,
-			);
-			path = lliaw;
-			sourceTree = "<group>";
-		};
-		1362E3E911AE7D5C00AF3D9A /* 1 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3EA11AE7D5C00AF3D9A /* default.xml */,
-				1362E3EB11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 1;
-			sourceTree = "<group>";
-		};
-		1362E3EC11AE7D5C00AF3D9A /* 10 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3ED11AE7D5C00AF3D9A /* default.xml */,
-				1362E3EE11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 10;
-			sourceTree = "<group>";
-		};
-		1362E3EF11AE7D5C00AF3D9A /* 2 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3F011AE7D5C00AF3D9A /* default.xml */,
-				1362E3F111AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 2;
-			sourceTree = "<group>";
-		};
-		1362E3F211AE7D5C00AF3D9A /* 3 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3F311AE7D5C00AF3D9A /* car1-trb1.rgb */,
-				1362E3F411AE7D5C00AF3D9A /* default.xml */,
-				1362E3F511AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 3;
-			sourceTree = "<group>";
-		};
-		1362E3F611AE7D5C00AF3D9A /* 4 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3F711AE7D5C00AF3D9A /* car2-trb1.rgb */,
-				1362E3F811AE7D5C00AF3D9A /* default.xml */,
-				1362E3F911AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 4;
-			sourceTree = "<group>";
-		};
-		1362E3FA11AE7D5C00AF3D9A /* 5 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3FB11AE7D5C00AF3D9A /* car3-trb1.rgb */,
-				1362E3FC11AE7D5C00AF3D9A /* default.xml */,
-				1362E3FD11AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 5;
-			sourceTree = "<group>";
-		};
-		1362E3FE11AE7D5C00AF3D9A /* 6 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E3FF11AE7D5C00AF3D9A /* car4-trb1.rgb */,
-				1362E40011AE7D5C00AF3D9A /* default.xml */,
-				1362E40111AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 6;
-			sourceTree = "<group>";
-		};
-		1362E40211AE7D5C00AF3D9A /* 7 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E40311AE7D5C00AF3D9A /* car5-trb1.rgb */,
-				1362E40411AE7D5C00AF3D9A /* default.xml */,
-				1362E40511AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 7;
-			sourceTree = "<group>";
-		};
-		1362E40611AE7D5C00AF3D9A /* 8 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E40711AE7D5C00AF3D9A /* car6-trb1.rgb */,
-				1362E40811AE7D5C00AF3D9A /* default.xml */,
-				1362E40911AE7D5C00AF3D9A /* Makefile */,
-			);
-			path = 8;
-			sourceTree = "<group>";
-		};
-		1362E40A11AE7D5C00AF3D9A /* 9 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E40B11AE7D5C00AF3D9A /* car7-trb1.rgb */,
-				1362E40C11AE7D5C00AF3D9A /* default.xml */,
-				1362E40D11AE7D5C00AF3D9A /* Makefile */,
 			);
 			path = 9;
 			sourceTree = "<group>";
@@ -4191,136 +4341,6 @@
 			path = 0;
 			sourceTree = "<group>";
 		};
-		1362E47911AE7D5D00AF3D9A /* tita */ = {
-			isa = PBXGroup;
-			children = (
-				1362E47A11AE7D5D00AF3D9A /* 1 */,
-				1362E47D11AE7D5D00AF3D9A /* 10 */,
-				1362E48011AE7D5D00AF3D9A /* 2 */,
-				1362E48311AE7D5D00AF3D9A /* 3 */,
-				1362E48711AE7D5D00AF3D9A /* 4 */,
-				1362E48B11AE7D5D00AF3D9A /* 5 */,
-				1362E48F11AE7D5D00AF3D9A /* 6 */,
-				1362E49311AE7D5D00AF3D9A /* 7 */,
-				1362E49711AE7D5D00AF3D9A /* 8 */,
-				1362E49B11AE7D5D00AF3D9A /* 9 */,
-				1362E49F11AE7D5D00AF3D9A /* berniw.h */,
-				1362E4A011AE7D5D00AF3D9A /* logo.rgb */,
-				1362E4A111AE7D5D00AF3D9A /* Makefile */,
-				1362E4A211AE7D5D00AF3D9A /* mycar.cpp */,
-				1362E4A311AE7D5D00AF3D9A /* mycar.h */,
-				1362E4A411AE7D5D00AF3D9A /* pathfinder.cpp */,
-				1362E4A511AE7D5D00AF3D9A /* pathfinder.h */,
-				1362E4A611AE7D5D00AF3D9A /* readme.html */,
-				1362E4A711AE7D5D00AF3D9A /* spline.cpp */,
-				1362E4A811AE7D5D00AF3D9A /* spline.h */,
-				1362E4A911AE7D5D00AF3D9A /* tita.cpp */,
-				1362E4AA11AE7D5D00AF3D9A /* tita.def */,
-				1362E4AB11AE7D5D00AF3D9A /* tita.dsp */,
-				1362E4AC11AE7D5D00AF3D9A /* tita.xml */,
-				1362E4AD11AE7D5D00AF3D9A /* trackdesc.cpp */,
-				1362E4AE11AE7D5D00AF3D9A /* trackdesc.h */,
-			);
-			path = tita;
-			sourceTree = "<group>";
-		};
-		1362E47A11AE7D5D00AF3D9A /* 1 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E47B11AE7D5D00AF3D9A /* default.xml */,
-				1362E47C11AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 1;
-			sourceTree = "<group>";
-		};
-		1362E47D11AE7D5D00AF3D9A /* 10 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E47E11AE7D5D00AF3D9A /* default.xml */,
-				1362E47F11AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 10;
-			sourceTree = "<group>";
-		};
-		1362E48011AE7D5D00AF3D9A /* 2 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E48111AE7D5D00AF3D9A /* default.xml */,
-				1362E48211AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 2;
-			sourceTree = "<group>";
-		};
-		1362E48311AE7D5D00AF3D9A /* 3 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E48411AE7D5D00AF3D9A /* car1-trb1.rgb */,
-				1362E48511AE7D5D00AF3D9A /* default.xml */,
-				1362E48611AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 3;
-			sourceTree = "<group>";
-		};
-		1362E48711AE7D5D00AF3D9A /* 4 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E48811AE7D5D00AF3D9A /* car2-trb1.rgb */,
-				1362E48911AE7D5D00AF3D9A /* default.xml */,
-				1362E48A11AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 4;
-			sourceTree = "<group>";
-		};
-		1362E48B11AE7D5D00AF3D9A /* 5 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E48C11AE7D5D00AF3D9A /* car3-trb1.rgb */,
-				1362E48D11AE7D5D00AF3D9A /* default.xml */,
-				1362E48E11AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 5;
-			sourceTree = "<group>";
-		};
-		1362E48F11AE7D5D00AF3D9A /* 6 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E49011AE7D5D00AF3D9A /* car4-trb1.rgb */,
-				1362E49111AE7D5D00AF3D9A /* default.xml */,
-				1362E49211AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 6;
-			sourceTree = "<group>";
-		};
-		1362E49311AE7D5D00AF3D9A /* 7 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E49411AE7D5D00AF3D9A /* car5-trb1.rgb */,
-				1362E49511AE7D5D00AF3D9A /* default.xml */,
-				1362E49611AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 7;
-			sourceTree = "<group>";
-		};
-		1362E49711AE7D5D00AF3D9A /* 8 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E49811AE7D5D00AF3D9A /* car6-trb1.rgb */,
-				1362E49911AE7D5D00AF3D9A /* default.xml */,
-				1362E49A11AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 8;
-			sourceTree = "<group>";
-		};
-		1362E49B11AE7D5D00AF3D9A /* 9 */ = {
-			isa = PBXGroup;
-			children = (
-				1362E49C11AE7D5D00AF3D9A /* car7-trb1.rgb */,
-				1362E49D11AE7D5D00AF3D9A /* default.xml */,
-				1362E49E11AE7D5D00AF3D9A /* Makefile */,
-			);
-			path = 9;
-			sourceTree = "<group>";
-		};
 		1362F80011AF009300AF3D9A /* linux */ = {
 			isa = PBXGroup;
 			children = (
@@ -4393,6 +4413,10 @@
 				1362E7D111AE7ED600AF3D9A /* olethros.so */,
 				1362E80311AE7F4B00AF3D9A /* sparkle.so */,
 				1362E81B11AE7F6800AF3D9A /* tita.so */,
+				FC53B48F189FDEF400F96E81 /* cylos1.so */,
+				FC53B49A189FF67100F96E81 /* K1999.so */,
+				FC53B4A3189FF6ED00F96E81 /* cylos2.so */,
+				FC53B4AF18A2548600F96E81 /* tanhoj.so */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4432,6 +4456,1023 @@
 				0FEABC8D0DADBCE800FE87DD /* libpng.framework */,
 			);
 			name = "Internal Frameworks";
+			sourceTree = "<group>";
+		};
+		FCB52F4A189FA8FC007E6151 /* lliaw */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52F4B189FA8FC007E6151 /* .xvpics */,
+				FCB52F4E189FA8FC007E6151 /* car-nascar.xml */,
+				FCB52F4F189FA8FC007E6151 /* car-torcs.xml */,
+				FCB52F50189FA8FC007E6151 /* car-viper.xml */,
+				FCB52F51189FA8FC007E6151 /* car.xml */,
+				FCB52F52189FA8FC007E6151 /* common.cpp */,
+				FCB52F53189FA8FC007E6151 /* common.h */,
+				FCB52F54189FA8FC007E6151 /* lliaw.cpp */,
+				FCB52F55189FA8FC007E6151 /* lliaw.def */,
+				FCB52F56189FA8FC007E6151 /* lliaw.dsp */,
+				FCB52F57189FA8FC007E6151 /* lliaw.vcproj */,
+				FCB52F58189FA8FC007E6151 /* lliaw.xml */,
+				FCB52F59189FA8FC007E6151 /* logo.rgb */,
+				FCB52F5A189FA8FC007E6151 /* Makefile */,
+				FCB52F5B189FA8FC007E6151 /* tracksdata */,
+				FCB52F62189FA8FC007E6151 /* viper-gts-r.rgb */,
+			);
+			path = lliaw;
+			sourceTree = "<group>";
+		};
+		FCB52F4B189FA8FC007E6151 /* .xvpics */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52F4C189FA8FC007E6151 /* logo.rgb */,
+				FCB52F4D189FA8FC007E6151 /* viper-gts-r.rgb */,
+			);
+			path = .xvpics;
+			sourceTree = "<group>";
+		};
+		FCB52F5B189FA8FC007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52F5C189FA8FC007E6151 /* car_e-track-3.xml */,
+				FCB52F5D189FA8FC007E6151 /* car_e-track-4.xml */,
+				FCB52F5E189FA8FC007E6151 /* car_e-track-6.xml */,
+				FCB52F5F189FA8FC007E6151 /* car_eroad.xml */,
+				FCB52F60189FA8FC007E6151 /* car_g-track-3.xml */,
+				FCB52F61189FA8FC007E6151 /* Makefile */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB52F9D189FAC33007E6151 /* damned */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52F9E189FAC33007E6151 /* 1 */,
+				FCB52FA4189FAC33007E6151 /* 10 */,
+				FCB52FA9189FAC33007E6151 /* 2 */,
+				FCB52FAF189FAC33007E6151 /* 3 */,
+				FCB52FB5189FAC33007E6151 /* 4 */,
+				FCB52FBC189FAC33007E6151 /* 5 */,
+				FCB52FC3189FAC33007E6151 /* 6 */,
+				FCB52FC9189FAC33007E6151 /* 7 */,
+				FCB52FD0189FAC33007E6151 /* 8 */,
+				FCB52FD5189FAC33007E6151 /* 9 */,
+				FCB52FDA189FAC33007E6151 /* car1.xml */,
+				FCB52FDB189FAC33007E6151 /* damned.cpp */,
+				FCB52FDC189FAC33007E6151 /* damned.def */,
+				FCB52FDD189FAC33007E6151 /* damned.dsp */,
+				FCB52FDE189FAC33007E6151 /* damned.vcproj */,
+				FCB52FDF189FAC33007E6151 /* damned.xml */,
+				FCB52FE0189FAC33007E6151 /* logo.rgb */,
+				FCB52FE1189FAC33007E6151 /* Makefile */,
+			);
+			path = damned;
+			sourceTree = "<group>";
+		};
+		FCB52F9E189FAC33007E6151 /* 1 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52F9F189FAC33007E6151 /* buggy.rgb */,
+				FCB52FA0189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FA1189FAC33007E6151 /* car.xml */,
+				FCB52FA2189FAC33007E6151 /* logo.rgb */,
+				FCB52FA3189FAC33007E6151 /* Makefile */,
+			);
+			path = 1;
+			sourceTree = "<group>";
+		};
+		FCB52FA4189FAC33007E6151 /* 10 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FA5189FAC33007E6151 /* 155-DTM.rgb */,
+				FCB52FA6189FAC33007E6151 /* car.xml */,
+				FCB52FA7189FAC33007E6151 /* logo.rgb */,
+				FCB52FA8189FAC33007E6151 /* Makefile */,
+			);
+			path = 10;
+			sourceTree = "<group>";
+		};
+		FCB52FA9189FAC33007E6151 /* 2 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FAA189FAC33007E6151 /* buggy.rgb */,
+				FCB52FAB189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FAC189FAC33007E6151 /* car.xml */,
+				FCB52FAD189FAC33007E6151 /* logo.rgb */,
+				FCB52FAE189FAC33007E6151 /* Makefile */,
+			);
+			path = 2;
+			sourceTree = "<group>";
+		};
+		FCB52FAF189FAC33007E6151 /* 3 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FB0189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FB1189FAC33007E6151 /* car.xml */,
+				FCB52FB2189FAC33007E6151 /* logo.rgb */,
+				FCB52FB3189FAC33007E6151 /* Makefile */,
+				FCB52FB4189FAC33007E6151 /* p406.rgb */,
+			);
+			path = 3;
+			sourceTree = "<group>";
+		};
+		FCB52FB5189FAC33007E6151 /* 4 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FB6189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FB7189FAC33007E6151 /* car.xml */,
+				FCB52FB8189FAC33007E6151 /* logo.rgb */,
+				FCB52FB9189FAC33007E6151 /* Makefile */,
+				FCB52FBA189FAC33007E6151 /* p406.rgb */,
+				FCB52FBB189FAC33007E6151 /* torcs.rgb */,
+			);
+			path = 4;
+			sourceTree = "<group>";
+		};
+		FCB52FBC189FAC33007E6151 /* 5 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FBD189FAC33007E6151 /* acura-nsx-sz-512.rgb */,
+				FCB52FBE189FAC33007E6151 /* acura-nsx-sz.rgb */,
+				FCB52FBF189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FC0189FAC33007E6151 /* car.xml */,
+				FCB52FC1189FAC33007E6151 /* logo.rgb */,
+				FCB52FC2189FAC33007E6151 /* Makefile */,
+			);
+			path = 5;
+			sourceTree = "<group>";
+		};
+		FCB52FC3189FAC33007E6151 /* 6 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FC4189FAC33007E6151 /* acura-nsx-sz.rgb */,
+				FCB52FC5189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FC6189FAC33007E6151 /* car.xml */,
+				FCB52FC7189FAC33007E6151 /* logo.rgb */,
+				FCB52FC8189FAC33007E6151 /* Makefile */,
+			);
+			path = 6;
+			sourceTree = "<group>";
+		};
+		FCB52FC9189FAC33007E6151 /* 7 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FCA189FAC33007E6151 /* car-dirt.xml */,
+				FCB52FCB189FAC33007E6151 /* car.xml */,
+				FCB52FCC189FAC33007E6151 /* logo.rgb */,
+				FCB52FCD189FAC33007E6151 /* Makefile */,
+				FCB52FCE189FAC33007E6151 /* porsche-gt1.rgb */,
+				FCB52FCF189FAC33007E6151 /* viper-gts-r.rgb */,
+			);
+			path = 7;
+			sourceTree = "<group>";
+		};
+		FCB52FD0189FAC33007E6151 /* 8 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FD1189FAC33007E6151 /* car.xml */,
+				FCB52FD2189FAC33007E6151 /* logo.rgb */,
+				FCB52FD3189FAC33007E6151 /* Makefile */,
+				FCB52FD4189FAC33007E6151 /* mclaren-f1.rgb */,
+			);
+			path = 8;
+			sourceTree = "<group>";
+		};
+		FCB52FD5189FAC33007E6151 /* 9 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB52FD6189FAC33007E6151 /* 360-modena.rgb */,
+				FCB52FD7189FAC33007E6151 /* car.xml */,
+				FCB52FD8189FAC33007E6151 /* logo.rgb */,
+				FCB52FD9189FAC33007E6151 /* Makefile */,
+			);
+			path = 9;
+			sourceTree = "<group>";
+		};
+		FCB531E2189FB00D007E6151 /* tita */ = {
+			isa = PBXGroup;
+			children = (
+				FCB531E3189FB00D007E6151 /* .xvpics */,
+				FCB531E6189FB00D007E6151 /* car.xml */,
+				FCB531E7189FB00D007E6151 /* common.cpp */,
+				FCB531E8189FB00D007E6151 /* common.h */,
+				FCB531E9189FB00D007E6151 /* logo.rgb */,
+				FCB531EA189FB00D007E6151 /* lotus-gt1-512.rgb */,
+				FCB531EB189FB00D007E6151 /* lotus-gt1.rgb */,
+				FCB531EC189FB00D007E6151 /* Makefile */,
+				FCB531ED189FB00D007E6151 /* tita.cpp */,
+				FCB531EE189FB00D007E6151 /* tita.def */,
+				FCB531EF189FB00D007E6151 /* tita.dsp */,
+				FCB531F0189FB00D007E6151 /* tita.vcproj */,
+				FCB531F1189FB00D007E6151 /* tita.xml */,
+				FCB531F2189FB00D007E6151 /* tracksdata */,
+			);
+			path = tita;
+			sourceTree = "<group>";
+		};
+		FCB531E3189FB00D007E6151 /* .xvpics */ = {
+			isa = PBXGroup;
+			children = (
+				FCB531E4189FB00D007E6151 /* logo.rgb */,
+				FCB531E5189FB00D007E6151 /* lotus-gt1.rgb */,
+			);
+			path = .xvpics;
+			sourceTree = "<group>";
+		};
+		FCB531F2189FB00D007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB531F3189FB00D007E6151 /* a-speedway.xml */,
+				FCB531F4189FB00D007E6151 /* aalborg.xml */,
+				FCB531F5189FB00D007E6151 /* car_a-speedway.xml */,
+				FCB531F6189FB00D007E6151 /* car_aalborg.xml */,
+				FCB531F7189FB00D007E6151 /* car_e-track-1.xml */,
+				FCB531F8189FB00D007E6151 /* car_e-track-2.xml */,
+				FCB531F9189FB00D007E6151 /* car_e-track-3.xml */,
+				FCB531FA189FB00D007E6151 /* car_e-track-4.xml */,
+				FCB531FB189FB00D007E6151 /* car_e-track-5.xml */,
+				FCB531FC189FB00D007E6151 /* car_e-track-6.xml */,
+				FCB531FD189FB00D007E6151 /* car_eroad.xml */,
+				FCB531FE189FB00D007E6151 /* car_g-track-1.xml */,
+				FCB531FF189FB00D007E6151 /* car_g-track-3.xml */,
+				FCB53200189FB00D007E6151 /* car_michigan.xml */,
+				FCB53201189FB00D007E6151 /* car_s2.xml */,
+				FCB53202189FB00D007E6151 /* car_test-1.xml */,
+				FCB53203189FB00D007E6151 /* car_wheel-1.xml */,
+				FCB53204189FB00D007E6151 /* city-1.xml */,
+				FCB53205189FB00D007E6151 /* e-track-1.xml */,
+				FCB53206189FB00D007E6151 /* e-track-2.xml */,
+				FCB53207189FB00D007E6151 /* e-track-3.xml */,
+				FCB53208189FB00D007E6151 /* e-track-4.xml */,
+				FCB53209189FB00D007E6151 /* e-track-5.xml */,
+				FCB5320A189FB00D007E6151 /* e-track-6.xml */,
+				FCB5320B189FB00D007E6151 /* eroad.xml */,
+				FCB5320C189FB00D007E6151 /* g-track-1.xml */,
+				FCB5320D189FB00D007E6151 /* g-track-3.xml */,
+				FCB5320E189FB00D007E6151 /* Makefile */,
+				FCB5320F189FB00D007E6151 /* michigan.xml */,
+				FCB53210189FB00D007E6151 /* s2.xml */,
+				FCB53211189FB00D007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53217189FB037007E6151 /* inferno */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53218189FB037007E6151 /* 1 */,
+				FCB53246189FB037007E6151 /* 10 */,
+				FCB53267189FB037007E6151 /* 2 */,
+				FCB53293189FB037007E6151 /* 3 */,
+				FCB532C7189FB037007E6151 /* 4 */,
+				FCB532F6189FB038007E6151 /* 5 */,
+				FCB53317189FB038007E6151 /* 6 */,
+				FCB53341189FB038007E6151 /* 7 */,
+				FCB5336F189FB038007E6151 /* 8 */,
+				FCB53396189FB038007E6151 /* 9 */,
+				FCB533C4189FB038007E6151 /* car1.xml */,
+				FCB533C5189FB038007E6151 /* common.cpp */,
+				FCB533C6189FB038007E6151 /* common.h */,
+				FCB533C7189FB038007E6151 /* inferno.cpp */,
+				FCB533C8189FB038007E6151 /* inferno.def */,
+				FCB533C9189FB038007E6151 /* inferno.dsp */,
+				FCB533CA189FB038007E6151 /* inferno.vcproj */,
+				FCB533CB189FB038007E6151 /* inferno.xml */,
+				FCB533CC189FB038007E6151 /* logo.rgb */,
+				FCB533CD189FB038007E6151 /* Makefile */,
+				FCB533CE189FB038007E6151 /* mclaren-f1.rgb */,
+			);
+			path = inferno;
+			sourceTree = "<group>";
+		};
+		FCB53218189FB037007E6151 /* 1 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53219189FB037007E6151 /* default.xml */,
+				FCB5321A189FB037007E6151 /* defaultcar.xml */,
+				FCB5321B189FB037007E6151 /* logo.rgb */,
+				FCB5321C189FB037007E6151 /* Makefile */,
+				FCB5321D189FB037007E6151 /* mclaren-f1.rgb */,
+				FCB5321E189FB037007E6151 /* tracksdata */,
+			);
+			path = 1;
+			sourceTree = "<group>";
+		};
+		FCB5321E189FB037007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5321F189FB037007E6151 /* a-speedway.xml */,
+				FCB53220189FB037007E6151 /* aalborg.xml */,
+				FCB53221189FB037007E6151 /* alpine-1.xml */,
+				FCB53222189FB037007E6151 /* b-speedway.xml */,
+				FCB53223189FB037007E6151 /* c-speedway.xml */,
+				FCB53224189FB037007E6151 /* car_a-speedway.xml */,
+				FCB53225189FB037007E6151 /* car_aalborg.xml */,
+				FCB53226189FB037007E6151 /* car_e-track-1.xml */,
+				FCB53227189FB037007E6151 /* car_e-track-2.xml */,
+				FCB53228189FB037007E6151 /* car_e-track-3.xml */,
+				FCB53229189FB037007E6151 /* car_e-track-4.xml */,
+				FCB5322A189FB037007E6151 /* car_e-track-5.xml */,
+				FCB5322B189FB037007E6151 /* car_e-track-6.xml */,
+				FCB5322C189FB037007E6151 /* car_eroad.xml */,
+				FCB5322D189FB037007E6151 /* car_g-speedway.xml */,
+				FCB5322E189FB037007E6151 /* car_g-track-1.xml */,
+				FCB5322F189FB037007E6151 /* car_g-track-2.xml */,
+				FCB53230189FB037007E6151 /* car_michigan.xml */,
+				FCB53231189FB037007E6151 /* car_s2.xml */,
+				FCB53232189FB037007E6151 /* car_test-1.xml */,
+				FCB53233189FB037007E6151 /* car_wheel-1.xml */,
+				FCB53234189FB037007E6151 /* city-1.xml */,
+				FCB53235189FB037007E6151 /* d-speedway.xml */,
+				FCB53236189FB037007E6151 /* e-speedway.xml */,
+				FCB53237189FB037007E6151 /* e-track-1.xml */,
+				FCB53238189FB037007E6151 /* e-track-2.xml */,
+				FCB53239189FB037007E6151 /* e-track-3.xml */,
+				FCB5323A189FB037007E6151 /* e-track-4.xml */,
+				FCB5323B189FB037007E6151 /* e-track-5.xml */,
+				FCB5323C189FB037007E6151 /* e-track-6.xml */,
+				FCB5323D189FB037007E6151 /* eroad.xml */,
+				FCB5323E189FB037007E6151 /* f-speedway.xml */,
+				FCB5323F189FB037007E6151 /* g-speedway.xml */,
+				FCB53240189FB037007E6151 /* g-track-1.xml */,
+				FCB53241189FB037007E6151 /* g-track-2.xml */,
+				FCB53242189FB037007E6151 /* Makefile */,
+				FCB53243189FB037007E6151 /* michigan.xml */,
+				FCB53244189FB037007E6151 /* s2.xml */,
+				FCB53245189FB037007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53246189FB037007E6151 /* 10 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53247189FB037007E6151 /* default.xml */,
+				FCB53248189FB037007E6151 /* defaultcar.xml */,
+				FCB53249189FB037007E6151 /* logo.rgb */,
+				FCB5324A189FB037007E6151 /* Makefile */,
+				FCB5324B189FB037007E6151 /* tracksdata */,
+				FCB53266189FB037007E6151 /* vm-x4.rgb */,
+			);
+			path = 10;
+			sourceTree = "<group>";
+		};
+		FCB5324B189FB037007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5324C189FB037007E6151 /* a-speedway.xml */,
+				FCB5324D189FB037007E6151 /* aalborg.xml */,
+				FCB5324E189FB037007E6151 /* b-speedway.xml */,
+				FCB5324F189FB037007E6151 /* c-speedway.xml */,
+				FCB53250189FB037007E6151 /* car_e-track-2.xml */,
+				FCB53251189FB037007E6151 /* car_e-track-4.xml */,
+				FCB53252189FB037007E6151 /* car_e-track-6.xml */,
+				FCB53253189FB037007E6151 /* car_g-speedway.xml */,
+				FCB53254189FB037007E6151 /* car_g-track-1.xml */,
+				FCB53255189FB037007E6151 /* car_g-track-2.xml */,
+				FCB53256189FB037007E6151 /* d-speedway.xml */,
+				FCB53257189FB037007E6151 /* e-speedway.xml */,
+				FCB53258189FB037007E6151 /* e-track-1.xml */,
+				FCB53259189FB037007E6151 /* e-track-2.xml */,
+				FCB5325A189FB037007E6151 /* e-track-3.xml */,
+				FCB5325B189FB037007E6151 /* e-track-4.xml */,
+				FCB5325C189FB037007E6151 /* e-track-5.xml */,
+				FCB5325D189FB037007E6151 /* e-track-6.xml */,
+				FCB5325E189FB037007E6151 /* eroad.xml */,
+				FCB5325F189FB037007E6151 /* f-speedway.xml */,
+				FCB53260189FB037007E6151 /* g-speedway.xml */,
+				FCB53261189FB037007E6151 /* g-track-1.xml */,
+				FCB53262189FB037007E6151 /* g-track-2.xml */,
+				FCB53263189FB037007E6151 /* Makefile */,
+				FCB53264189FB037007E6151 /* michigan.xml */,
+				FCB53265189FB037007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53267189FB037007E6151 /* 2 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53268189FB037007E6151 /* 360-modena.rgb */,
+				FCB53269189FB037007E6151 /* default.xml */,
+				FCB5326A189FB037007E6151 /* defaultcar.xml */,
+				FCB5326B189FB037007E6151 /* logo.rgb */,
+				FCB5326C189FB037007E6151 /* Makefile */,
+				FCB5326D189FB037007E6151 /* tracksdata */,
+			);
+			path = 2;
+			sourceTree = "<group>";
+		};
+		FCB5326D189FB037007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5326E189FB037007E6151 /* a-speedway.xml */,
+				FCB5326F189FB037007E6151 /* aalborg.xml */,
+				FCB53270189FB037007E6151 /* b-speedway.xml */,
+				FCB53271189FB037007E6151 /* c-speedway.xml */,
+				FCB53272189FB037007E6151 /* car_a-speedway.xml */,
+				FCB53273189FB037007E6151 /* car_aalborg.xml */,
+				FCB53274189FB037007E6151 /* car_e-track-1.xml */,
+				FCB53275189FB037007E6151 /* car_e-track-2.xml */,
+				FCB53276189FB037007E6151 /* car_e-track-3.xml */,
+				FCB53277189FB037007E6151 /* car_e-track-4.xml */,
+				FCB53278189FB037007E6151 /* car_e-track-5.xml */,
+				FCB53279189FB037007E6151 /* car_e-track-6.xml */,
+				FCB5327A189FB037007E6151 /* car_eroad.xml */,
+				FCB5327B189FB037007E6151 /* car_g-speedway.xml */,
+				FCB5327C189FB037007E6151 /* car_g-track-1.xml */,
+				FCB5327D189FB037007E6151 /* car_g-track-2.xml */,
+				FCB5327E189FB037007E6151 /* car_michigan.xml */,
+				FCB5327F189FB037007E6151 /* car_s2.xml */,
+				FCB53280189FB037007E6151 /* car_test-1.xml */,
+				FCB53281189FB037007E6151 /* car_wheel-1.xml */,
+				FCB53282189FB037007E6151 /* d-speedway.xml */,
+				FCB53283189FB037007E6151 /* e-speedway.xml */,
+				FCB53284189FB037007E6151 /* e-track-1.xml */,
+				FCB53285189FB037007E6151 /* e-track-2.xml */,
+				FCB53286189FB037007E6151 /* e-track-3.xml */,
+				FCB53287189FB037007E6151 /* e-track-4.xml */,
+				FCB53288189FB037007E6151 /* e-track-5.xml */,
+				FCB53289189FB037007E6151 /* e-track-6.xml */,
+				FCB5328A189FB037007E6151 /* eroad.xml */,
+				FCB5328B189FB037007E6151 /* f-speedway.xml */,
+				FCB5328C189FB037007E6151 /* g-speedway.xml */,
+				FCB5328D189FB037007E6151 /* g-track-1.xml */,
+				FCB5328E189FB037007E6151 /* g-track-2.xml */,
+				FCB5328F189FB037007E6151 /* Makefile */,
+				FCB53290189FB037007E6151 /* michigan.xml */,
+				FCB53291189FB037007E6151 /* s2.xml */,
+				FCB53292189FB037007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53293189FB037007E6151 /* 3 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53294189FB037007E6151 /* default.xml */,
+				FCB53295189FB037007E6151 /* defaultcar.xml */,
+				FCB53296189FB037007E6151 /* logo.rgb */,
+				FCB53297189FB037007E6151 /* Makefile */,
+				FCB53298189FB037007E6151 /* porsche-gt1.rgb */,
+				FCB53299189FB037007E6151 /* tracksdata */,
+			);
+			path = 3;
+			sourceTree = "<group>";
+		};
+		FCB53299189FB037007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5329A189FB037007E6151 /* a-speedway.xml */,
+				FCB5329B189FB037007E6151 /* aalborg.xml */,
+				FCB5329C189FB037007E6151 /* alpine-1.xml */,
+				FCB5329D189FB037007E6151 /* b-speedway.xml */,
+				FCB5329E189FB037007E6151 /* c-speedway.xml */,
+				FCB5329F189FB037007E6151 /* car_a-speedway.xml */,
+				FCB532A0189FB037007E6151 /* car_aalborg.xml */,
+				FCB532A1189FB037007E6151 /* car_alpine-1.xml */,
+				FCB532A2189FB037007E6151 /* car_b-speedway.xml */,
+				FCB532A3189FB037007E6151 /* car_c-speedway.xml */,
+				FCB532A4189FB037007E6151 /* car_d-speedway.xml */,
+				FCB532A5189FB037007E6151 /* car_e-speedway.xml */,
+				FCB532A6189FB037007E6151 /* car_e-track-1.xml */,
+				FCB532A7189FB037007E6151 /* car_e-track-2.xml */,
+				FCB532A8189FB037007E6151 /* car_e-track-3.xml */,
+				FCB532A9189FB037007E6151 /* car_e-track-4.xml */,
+				FCB532AA189FB037007E6151 /* car_e-track-5.xml */,
+				FCB532AB189FB037007E6151 /* car_e-track-6.xml */,
+				FCB532AC189FB037007E6151 /* car_eroad.xml */,
+				FCB532AD189FB037007E6151 /* car_f-speedway.xml */,
+				FCB532AE189FB037007E6151 /* car_g-speedway.xml */,
+				FCB532AF189FB037007E6151 /* car_g-track-1.xml */,
+				FCB532B0189FB037007E6151 /* car_g-track-2.xml */,
+				FCB532B1189FB037007E6151 /* car_h-speedway.xml */,
+				FCB532B2189FB037007E6151 /* car_michigan.xml */,
+				FCB532B3189FB037007E6151 /* car_spring.xml */,
+				FCB532B4189FB037007E6151 /* car_wheel-1.xml */,
+				FCB532B5189FB037007E6151 /* d-speedway.xml */,
+				FCB532B6189FB037007E6151 /* e-speedway.xml */,
+				FCB532B7189FB037007E6151 /* e-track-1.xml */,
+				FCB532B8189FB037007E6151 /* e-track-2.xml */,
+				FCB532B9189FB037007E6151 /* e-track-3.xml */,
+				FCB532BA189FB037007E6151 /* e-track-4.xml */,
+				FCB532BB189FB037007E6151 /* e-track-5.xml */,
+				FCB532BC189FB037007E6151 /* e-track-6.xml */,
+				FCB532BD189FB037007E6151 /* eroad.xml */,
+				FCB532BE189FB037007E6151 /* f-speedway.xml */,
+				FCB532BF189FB037007E6151 /* g-speedway.xml */,
+				FCB532C0189FB037007E6151 /* g-track-1.xml */,
+				FCB532C1189FB037007E6151 /* g-track-2.xml */,
+				FCB532C2189FB037007E6151 /* h-speedway.xml */,
+				FCB532C3189FB037007E6151 /* Makefile */,
+				FCB532C4189FB037007E6151 /* michigan.xml */,
+				FCB532C5189FB037007E6151 /* spring.xml */,
+				FCB532C6189FB037007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB532C7189FB037007E6151 /* 4 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB532C8189FB037007E6151 /* clkdtm.rgb */,
+				FCB532C9189FB037007E6151 /* default.xml */,
+				FCB532CA189FB037007E6151 /* defaultcar.xml */,
+				FCB532CB189FB037007E6151 /* logo.rgb */,
+				FCB532CC189FB037007E6151 /* Makefile */,
+				FCB532CD189FB037007E6151 /* tracksdata */,
+				FCB532F5189FB038007E6151 /* wheel3d.png */,
+			);
+			path = 4;
+			sourceTree = "<group>";
+		};
+		FCB532CD189FB037007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB532CE189FB037007E6151 /* a-speedway.xml */,
+				FCB532CF189FB037007E6151 /* aalborg.xml */,
+				FCB532D0189FB037007E6151 /* alpine-1.xml */,
+				FCB532D1189FB037007E6151 /* b-speedway.xml */,
+				FCB532D2189FB037007E6151 /* c-speedway.xml */,
+				FCB532D3189FB037007E6151 /* car_a-speedway.xml */,
+				FCB532D4189FB037007E6151 /* car_aalborg.xml */,
+				FCB532D5189FB037007E6151 /* car_e-track-1.xml */,
+				FCB532D6189FB037007E6151 /* car_e-track-2.xml */,
+				FCB532D7189FB037007E6151 /* car_e-track-3.xml */,
+				FCB532D8189FB037007E6151 /* car_e-track-4.xml */,
+				FCB532D9189FB037007E6151 /* car_e-track-5.xml */,
+				FCB532DA189FB037007E6151 /* car_e-track-6.xml */,
+				FCB532DB189FB037007E6151 /* car_eroad.xml */,
+				FCB532DC189FB037007E6151 /* car_g-speedway.xml */,
+				FCB532DD189FB037007E6151 /* car_g-track-1.xml */,
+				FCB532DE189FB037007E6151 /* car_g-track-2.xml */,
+				FCB532DF189FB037007E6151 /* car_g-track-3.xml */,
+				FCB532E0189FB037007E6151 /* car_michigan.xml */,
+				FCB532E1189FB037007E6151 /* car_test-1.xml */,
+				FCB532E2189FB037007E6151 /* car_wheel-1.xml */,
+				FCB532E3189FB037007E6151 /* d-speedway.xml */,
+				FCB532E4189FB037007E6151 /* dirt-2.xml */,
+				FCB532E5189FB037007E6151 /* e-speedway.xml */,
+				FCB532E6189FB037007E6151 /* e-track-1.xml */,
+				FCB532E7189FB037007E6151 /* e-track-2.xml */,
+				FCB532E8189FB037007E6151 /* e-track-3.xml */,
+				FCB532E9189FB037007E6151 /* e-track-4.xml */,
+				FCB532EA189FB037007E6151 /* e-track-5.xml */,
+				FCB532EB189FB037007E6151 /* e-track-6.xml */,
+				FCB532EC189FB037007E6151 /* eroad.xml */,
+				FCB532ED189FB038007E6151 /* f-speedway.xml */,
+				FCB532EE189FB038007E6151 /* g-speedway.xml */,
+				FCB532EF189FB038007E6151 /* g-track-1.xml */,
+				FCB532F0189FB038007E6151 /* g-track-2.xml */,
+				FCB532F1189FB038007E6151 /* g-track-3.xml */,
+				FCB532F2189FB038007E6151 /* Makefile */,
+				FCB532F3189FB038007E6151 /* michigan.xml */,
+				FCB532F4189FB038007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB532F6189FB038007E6151 /* 5 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB532F7189FB038007E6151 /* default.xml */,
+				FCB532F8189FB038007E6151 /* defaultcar.xml */,
+				FCB532F9189FB038007E6151 /* gt40.rgb */,
+				FCB532FA189FB038007E6151 /* logo.rgb */,
+				FCB532FB189FB038007E6151 /* Makefile */,
+				FCB532FC189FB038007E6151 /* tracksdata */,
+			);
+			path = 5;
+			sourceTree = "<group>";
+		};
+		FCB532FC189FB038007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB532FD189FB038007E6151 /* a-speedway.xml */,
+				FCB532FE189FB038007E6151 /* aalborg.xml */,
+				FCB532FF189FB038007E6151 /* b-speedway.xml */,
+				FCB53300189FB038007E6151 /* c-speedway.xml */,
+				FCB53301189FB038007E6151 /* car_e-track-2.xml */,
+				FCB53302189FB038007E6151 /* car_e-track-4.xml */,
+				FCB53303189FB038007E6151 /* car_e-track-6.xml */,
+				FCB53304189FB038007E6151 /* car_g-speedway.xml */,
+				FCB53305189FB038007E6151 /* car_g-track-1.xml */,
+				FCB53306189FB038007E6151 /* car_g-track-2.xml */,
+				FCB53307189FB038007E6151 /* d-speedway.xml */,
+				FCB53308189FB038007E6151 /* e-speedway.xml */,
+				FCB53309189FB038007E6151 /* e-track-1.xml */,
+				FCB5330A189FB038007E6151 /* e-track-2.xml */,
+				FCB5330B189FB038007E6151 /* e-track-3.xml */,
+				FCB5330C189FB038007E6151 /* e-track-4.xml */,
+				FCB5330D189FB038007E6151 /* e-track-5.xml */,
+				FCB5330E189FB038007E6151 /* e-track-6.xml */,
+				FCB5330F189FB038007E6151 /* eroad.xml */,
+				FCB53310189FB038007E6151 /* f-speedway.xml */,
+				FCB53311189FB038007E6151 /* g-speedway.xml */,
+				FCB53312189FB038007E6151 /* g-track-1.xml */,
+				FCB53313189FB038007E6151 /* g-track-2.xml */,
+				FCB53314189FB038007E6151 /* Makefile */,
+				FCB53315189FB038007E6151 /* michigan.xml */,
+				FCB53316189FB038007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53317189FB038007E6151 /* 6 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53318189FB038007E6151 /* default.xml */,
+				FCB53319189FB038007E6151 /* defaultcar.xml */,
+				FCB5331A189FB038007E6151 /* logo.rgb */,
+				FCB5331B189FB038007E6151 /* Makefile */,
+				FCB5331C189FB038007E6151 /* porsche-gt3rs.rgb */,
+				FCB5331D189FB038007E6151 /* tracksdata */,
+			);
+			path = 6;
+			sourceTree = "<group>";
+		};
+		FCB5331D189FB038007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5331E189FB038007E6151 /* a-speedway.xml */,
+				FCB5331F189FB038007E6151 /* aalborg.xml */,
+				FCB53320189FB038007E6151 /* b-speedway.xml */,
+				FCB53321189FB038007E6151 /* c-speedway.xml */,
+				FCB53322189FB038007E6151 /* car_b-speedway.xml */,
+				FCB53323189FB038007E6151 /* car_c-speedway.xml */,
+				FCB53324189FB038007E6151 /* car_d-speedway.xml */,
+				FCB53325189FB038007E6151 /* car_e-speedway.xml */,
+				FCB53326189FB038007E6151 /* car_e-track-2.xml */,
+				FCB53327189FB038007E6151 /* car_e-track-4.xml */,
+				FCB53328189FB038007E6151 /* car_e-track-6.xml */,
+				FCB53329189FB038007E6151 /* car_f-speedway.xml */,
+				FCB5332A189FB038007E6151 /* car_g-speedway.xml */,
+				FCB5332B189FB038007E6151 /* car_g-track-1.xml */,
+				FCB5332C189FB038007E6151 /* car_g-track-2.xml */,
+				FCB5332D189FB038007E6151 /* car_g-track-3.xml */,
+				FCB5332E189FB038007E6151 /* car_michigan.xml */,
+				FCB5332F189FB038007E6151 /* car_wheel-1.xml */,
+				FCB53330189FB038007E6151 /* d-speedway.xml */,
+				FCB53331189FB038007E6151 /* e-speedway.xml */,
+				FCB53332189FB038007E6151 /* e-track-1.xml */,
+				FCB53333189FB038007E6151 /* e-track-2.xml */,
+				FCB53334189FB038007E6151 /* e-track-3.xml */,
+				FCB53335189FB038007E6151 /* e-track-4.xml */,
+				FCB53336189FB038007E6151 /* e-track-5.xml */,
+				FCB53337189FB038007E6151 /* e-track-6.xml */,
+				FCB53338189FB038007E6151 /* eroad.xml */,
+				FCB53339189FB038007E6151 /* f-speedway.xml */,
+				FCB5333A189FB038007E6151 /* g-speedway.xml */,
+				FCB5333B189FB038007E6151 /* g-track-1.xml */,
+				FCB5333C189FB038007E6151 /* g-track-2.xml */,
+				FCB5333D189FB038007E6151 /* g-track-3.xml */,
+				FCB5333E189FB038007E6151 /* Makefile */,
+				FCB5333F189FB038007E6151 /* michigan.xml */,
+				FCB53340189FB038007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53341189FB038007E6151 /* 7 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53342189FB038007E6151 /* default.xml */,
+				FCB53343189FB038007E6151 /* defaultcar.xml */,
+				FCB53344189FB038007E6151 /* logo.rgb */,
+				FCB53345189FB038007E6151 /* lotus-gt1.rgb */,
+				FCB53346189FB038007E6151 /* Makefile */,
+				FCB53347189FB038007E6151 /* tracksdata */,
+			);
+			path = 7;
+			sourceTree = "<group>";
+		};
+		FCB53347189FB038007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53348189FB038007E6151 /* a-speedway.xml */,
+				FCB53349189FB038007E6151 /* aalborg.xml */,
+				FCB5334A189FB038007E6151 /* alpine-1.xml */,
+				FCB5334B189FB038007E6151 /* b-speedway.xml */,
+				FCB5334C189FB038007E6151 /* c-speedway.xml */,
+				FCB5334D189FB038007E6151 /* car_a-speedway.xml */,
+				FCB5334E189FB038007E6151 /* car_aalborg.xml */,
+				FCB5334F189FB038007E6151 /* car_e-track-1.xml */,
+				FCB53350189FB038007E6151 /* car_e-track-2.xml */,
+				FCB53351189FB038007E6151 /* car_e-track-3.xml */,
+				FCB53352189FB038007E6151 /* car_e-track-4.xml */,
+				FCB53353189FB038007E6151 /* car_e-track-5.xml */,
+				FCB53354189FB038007E6151 /* car_e-track-6.xml */,
+				FCB53355189FB038007E6151 /* car_eroad.xml */,
+				FCB53356189FB038007E6151 /* car_g-speedway.xml */,
+				FCB53357189FB038007E6151 /* car_g-track-1.xml */,
+				FCB53358189FB038007E6151 /* car_g-track-2.xml */,
+				FCB53359189FB038007E6151 /* car_michigan.xml */,
+				FCB5335A189FB038007E6151 /* car_s2.xml */,
+				FCB5335B189FB038007E6151 /* car_test-1.xml */,
+				FCB5335C189FB038007E6151 /* car_wheel-1.xml */,
+				FCB5335D189FB038007E6151 /* city-1.xml */,
+				FCB5335E189FB038007E6151 /* d-speedway.xml */,
+				FCB5335F189FB038007E6151 /* e-speedway.xml */,
+				FCB53360189FB038007E6151 /* e-track-1.xml */,
+				FCB53361189FB038007E6151 /* e-track-2.xml */,
+				FCB53362189FB038007E6151 /* e-track-3.xml */,
+				FCB53363189FB038007E6151 /* e-track-4.xml */,
+				FCB53364189FB038007E6151 /* e-track-5.xml */,
+				FCB53365189FB038007E6151 /* e-track-6.xml */,
+				FCB53366189FB038007E6151 /* eroad.xml */,
+				FCB53367189FB038007E6151 /* f-speedway.xml */,
+				FCB53368189FB038007E6151 /* g-speedway.xml */,
+				FCB53369189FB038007E6151 /* g-track-1.xml */,
+				FCB5336A189FB038007E6151 /* g-track-2.xml */,
+				FCB5336B189FB038007E6151 /* Makefile */,
+				FCB5336C189FB038007E6151 /* michigan.xml */,
+				FCB5336D189FB038007E6151 /* s2.xml */,
+				FCB5336E189FB038007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB5336F189FB038007E6151 /* 8 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53370189FB038007E6151 /* default.xml */,
+				FCB53371189FB038007E6151 /* defaultcar.xml */,
+				FCB53372189FB038007E6151 /* logo.rgb */,
+				FCB53373189FB038007E6151 /* Makefile */,
+				FCB53374189FB038007E6151 /* p406.rgb */,
+				FCB53375189FB038007E6151 /* tracksdata */,
+			);
+			path = 8;
+			sourceTree = "<group>";
+		};
+		FCB53375189FB038007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53376189FB038007E6151 /* a-speedway.xml */,
+				FCB53377189FB038007E6151 /* aalborg.xml */,
+				FCB53378189FB038007E6151 /* alpine-1.xml */,
+				FCB53379189FB038007E6151 /* b-speedway.xml */,
+				FCB5337A189FB038007E6151 /* c-speedway.xml */,
+				FCB5337B189FB038007E6151 /* car_dirt-1.xml */,
+				FCB5337C189FB038007E6151 /* car_dirt-2.xml */,
+				FCB5337D189FB038007E6151 /* car_dirt-3.xml */,
+				FCB5337E189FB038007E6151 /* car_dirt-4.xml */,
+				FCB5337F189FB038007E6151 /* car_dirt-5.xml */,
+				FCB53380189FB038007E6151 /* car_dirt-6.xml */,
+				FCB53381189FB038007E6151 /* car_g-track-3.xml */,
+				FCB53382189FB038007E6151 /* car_mixed-1.xml */,
+				FCB53383189FB038007E6151 /* car_mixed-2.xml */,
+				FCB53384189FB038007E6151 /* d-speedway.xml */,
+				FCB53385189FB038007E6151 /* e-speedway.xml */,
+				FCB53386189FB038007E6151 /* e-track-1.xml */,
+				FCB53387189FB038007E6151 /* e-track-2.xml */,
+				FCB53388189FB038007E6151 /* e-track-3.xml */,
+				FCB53389189FB038007E6151 /* e-track-4.xml */,
+				FCB5338A189FB038007E6151 /* e-track-5.xml */,
+				FCB5338B189FB038007E6151 /* e-track-6.xml */,
+				FCB5338C189FB038007E6151 /* eroad.xml */,
+				FCB5338D189FB038007E6151 /* f-speedway.xml */,
+				FCB5338E189FB038007E6151 /* g-speedway.xml */,
+				FCB5338F189FB038007E6151 /* g-track-1.xml */,
+				FCB53390189FB038007E6151 /* g-track-2.xml */,
+				FCB53391189FB038007E6151 /* g-track-3.xml */,
+				FCB53392189FB038007E6151 /* Makefile */,
+				FCB53393189FB038007E6151 /* michigan.xml */,
+				FCB53394189FB038007E6151 /* spring.xml */,
+				FCB53395189FB038007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53396189FB038007E6151 /* 9 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53397189FB038007E6151 /* default.xml */,
+				FCB53398189FB038007E6151 /* defaultcar.xml */,
+				FCB53399189FB038007E6151 /* logo.rgb */,
+				FCB5339A189FB038007E6151 /* Makefile */,
+				FCB5339B189FB038007E6151 /* tracksdata */,
+				FCB533C3189FB038007E6151 /* vm-x2.rgb */,
+			);
+			path = 9;
+			sourceTree = "<group>";
+		};
+		FCB5339B189FB038007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5339C189FB038007E6151 /* a-speedway.xml */,
+				FCB5339D189FB038007E6151 /* aalborg.xml */,
+				FCB5339E189FB038007E6151 /* alpine-1.xml */,
+				FCB5339F189FB038007E6151 /* b-speedway.xml */,
+				FCB533A0189FB038007E6151 /* c-speedway.xml */,
+				FCB533A1189FB038007E6151 /* car_a-speedway.xml */,
+				FCB533A2189FB038007E6151 /* car_aalborg.xml */,
+				FCB533A3189FB038007E6151 /* car_e-track-1.xml */,
+				FCB533A4189FB038007E6151 /* car_e-track-2.xml */,
+				FCB533A5189FB038007E6151 /* car_e-track-3.xml */,
+				FCB533A6189FB038007E6151 /* car_e-track-4.xml */,
+				FCB533A7189FB038007E6151 /* car_e-track-5.xml */,
+				FCB533A8189FB038007E6151 /* car_e-track-6.xml */,
+				FCB533A9189FB038007E6151 /* car_eroad.xml */,
+				FCB533AA189FB038007E6151 /* car_g-speedway.xml */,
+				FCB533AB189FB038007E6151 /* car_g-track-1.xml */,
+				FCB533AC189FB038007E6151 /* car_g-track-2.xml */,
+				FCB533AD189FB038007E6151 /* car_michigan.xml */,
+				FCB533AE189FB038007E6151 /* car_s2.xml */,
+				FCB533AF189FB038007E6151 /* car_test-1.xml */,
+				FCB533B0189FB038007E6151 /* car_wheel-1.xml */,
+				FCB533B1189FB038007E6151 /* city-1.xml */,
+				FCB533B2189FB038007E6151 /* d-speedway.xml */,
+				FCB533B3189FB038007E6151 /* e-speedway.xml */,
+				FCB533B4189FB038007E6151 /* e-track-1.xml */,
+				FCB533B5189FB038007E6151 /* e-track-2.xml */,
+				FCB533B6189FB038007E6151 /* e-track-3.xml */,
+				FCB533B7189FB038007E6151 /* e-track-4.xml */,
+				FCB533B8189FB038007E6151 /* e-track-5.xml */,
+				FCB533B9189FB038007E6151 /* e-track-6.xml */,
+				FCB533BA189FB038007E6151 /* eroad.xml */,
+				FCB533BB189FB038007E6151 /* f-speedway.xml */,
+				FCB533BC189FB038007E6151 /* g-speedway.xml */,
+				FCB533BD189FB038007E6151 /* g-track-1.xml */,
+				FCB533BE189FB038007E6151 /* g-track-2.xml */,
+				FCB533BF189FB038007E6151 /* Makefile */,
+				FCB533C0189FB038007E6151 /* michigan.xml */,
+				FCB533C1189FB038007E6151 /* s2.xml */,
+				FCB533C2189FB038007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB533E7189FB8C3007E6151 /* cylos1 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB533E8189FB8C3007E6151 /* car1.xml */,
+				FCB533E9189FB8C3007E6151 /* cg-nascar-rwd.rgb */,
+				FCB533EA189FB8C3007E6151 /* common.cpp */,
+				FCB533EB189FB8C3007E6151 /* common.h */,
+				FCB533EC189FB8C3007E6151 /* cylos1.cpp */,
+				FCB533ED189FB8C3007E6151 /* cylos1.def */,
+				FCB533EE189FB8C3007E6151 /* cylos1.dsp */,
+				FCB533EF189FB8C3007E6151 /* cylos1.vcproj */,
+				FCB533F0189FB8C3007E6151 /* cylos1.xml */,
+				FCB533F1189FB8C3007E6151 /* logo.rgb */,
+				FCB533F2189FB8C3007E6151 /* Makefile */,
+				FCB533F3189FB8C3007E6151 /* mkdepend */,
+				FCB533F4189FB8C3007E6151 /* tracksdata */,
+			);
+			path = cylos1;
+			sourceTree = "<group>";
+		};
+		FCB533F4189FB8C3007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB533F5189FB8C3007E6151 /* car_e-track-3.xml */,
+				FCB533F6189FB8C3007E6151 /* car_lemans.xml */,
+				FCB533F7189FB8C3007E6151 /* car_test-1.xml */,
+				FCB533F8189FB8C3007E6151 /* lemans.xml */,
+				FCB533F9189FB8C3007E6151 /* Makefile */,
+				FCB533FA189FB8C3007E6151 /* michigan.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB533FB189FB8C3007E6151 /* cylos2 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB533FC189FB8C3007E6151 /* car1.xml */,
+				FCB533FD189FB8C3007E6151 /* cg-nascar-rwd.rgb */,
+				FCB533FE189FB8C3007E6151 /* common.cpp */,
+				FCB533FF189FB8C3007E6151 /* common.h */,
+				FCB53400189FB8C3007E6151 /* cylos2.cpp */,
+				FCB53401189FB8C3007E6151 /* cylos2.def */,
+				FCB53402189FB8C3007E6151 /* cylos2.dsp */,
+				FCB53403189FB8C3007E6151 /* cylos2.xml */,
+				FCB53404189FB8C3007E6151 /* logo.rgb */,
+				FCB53405189FB8C3007E6151 /* Makefile */,
+				FCB53406189FB8C3007E6151 /* tracksdata */,
+			);
+			path = cylos2;
+			sourceTree = "<group>";
+		};
+		FCB53406189FB8C3007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53407189FB8C3007E6151 /* car_e-track-3.xml */,
+				FCB53408189FB8C3007E6151 /* Makefile */,
+				FCB53409189FB8C3007E6151 /* michigan.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB5340A189FB8C3007E6151 /* tanhoj */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5340B189FB8C3007E6151 /* .xvpics */,
+				FCB5340D189FB8C3007E6151 /* car1.xml */,
+				FCB5340E189FB8C3007E6151 /* cg-nascar-rwd.rgb */,
+				FCB5340F189FB8C3007E6151 /* common.cpp */,
+				FCB53410189FB8C3007E6151 /* common.h */,
+				FCB53411189FB8C3007E6151 /* logo.rgb */,
+				FCB53412189FB8C3007E6151 /* Makefile */,
+				FCB53413189FB8C3007E6151 /* tanhoj.cpp */,
+				FCB53414189FB8C3007E6151 /* tanhoj.def */,
+				FCB53415189FB8C3007E6151 /* tanhoj.dsp */,
+				FCB53416189FB8C3007E6151 /* tanhoj.vcproj */,
+				FCB53417189FB8C3007E6151 /* tanhoj.xml */,
+				FCB53418189FB8C3007E6151 /* tracksdata */,
+			);
+			path = tanhoj;
+			sourceTree = "<group>";
+		};
+		FCB5340B189FB8C3007E6151 /* .xvpics */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5340C189FB8C3007E6151 /* cg-nascar-rwd.rgb */,
+			);
+			path = .xvpics;
+			sourceTree = "<group>";
+		};
+		FCB53418189FB8C3007E6151 /* tracksdata */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53419189FB8C3007E6151 /* a-speedway.xml */,
+				FCB5341A189FB8C3007E6151 /* aalborg.xml */,
+				FCB5341B189FB8C3007E6151 /* car_a-speedway.xml */,
+				FCB5341C189FB8C3007E6151 /* car_aalborg.xml */,
+				FCB5341D189FB8C3007E6151 /* car_e-track-1.xml */,
+				FCB5341E189FB8C3007E6151 /* car_e-track-2.xml */,
+				FCB5341F189FB8C3007E6151 /* car_e-track-3.xml */,
+				FCB53420189FB8C3007E6151 /* car_e-track-4.xml */,
+				FCB53421189FB8C3007E6151 /* car_e-track-5.xml */,
+				FCB53422189FB8C3007E6151 /* car_e-track-6.xml */,
+				FCB53423189FB8C3007E6151 /* car_eroad.xml */,
+				FCB53424189FB8C3007E6151 /* car_g-track-1.xml */,
+				FCB53425189FB8C3007E6151 /* car_g-track-3.xml */,
+				FCB53426189FB8C3007E6151 /* car_michigan.xml */,
+				FCB53427189FB8C3007E6151 /* car_s2.xml */,
+				FCB53428189FB8C3007E6151 /* car_test-1.xml */,
+				FCB53429189FB8C3007E6151 /* car_wheel-1.xml */,
+				FCB5342A189FB8C3007E6151 /* city-1.xml */,
+				FCB5342B189FB8C3007E6151 /* dirt-2.xml */,
+				FCB5342C189FB8C3007E6151 /* e-track-1.xml */,
+				FCB5342D189FB8C3007E6151 /* e-track-2.xml */,
+				FCB5342E189FB8C3007E6151 /* e-track-3.xml */,
+				FCB5342F189FB8C3007E6151 /* e-track-4.xml */,
+				FCB53430189FB8C3007E6151 /* e-track-5.xml */,
+				FCB53431189FB8C3007E6151 /* e-track-6.xml */,
+				FCB53432189FB8C3007E6151 /* eroad.xml */,
+				FCB53433189FB8C3007E6151 /* g-track-1.xml */,
+				FCB53434189FB8C3007E6151 /* g-track-3.xml */,
+				FCB53435189FB8C3007E6151 /* Makefile */,
+				FCB53436189FB8C3007E6151 /* michigan.xml */,
+				FCB53437189FB8C3007E6151 /* s2.xml */,
+				FCB53438189FB8C3007E6151 /* wheel-1.xml */,
+			);
+			path = tracksdata;
+			sourceTree = "<group>";
+		};
+		FCB53439189FB8C3007E6151 /* K1999 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5343A189FB8C3007E6151 /* .xvpics */,
+				FCB5343D189FB8C3007E6151 /* 1 */,
+				FCB53441189FB8C3007E6151 /* 2 */,
+				FCB53445189FB8C3007E6151 /* K1999.cpp */,
+				FCB53446189FB8C3007E6151 /* K1999.def */,
+				FCB53447189FB8C3007E6151 /* K1999.dsp */,
+				FCB53448189FB8C3007E6151 /* K1999.xml */,
+				FCB53449189FB8C3007E6151 /* logo.rgb */,
+				FCB5344A189FB8C3007E6151 /* Makefile */,
+			);
+			path = K1999;
+			sourceTree = "<group>";
+		};
+		FCB5343A189FB8C3007E6151 /* .xvpics */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5343B189FB8C3007E6151 /* cg-nascar-rwd.rgb */,
+				FCB5343C189FB8C3007E6151 /* logo.rgb */,
+			);
+			path = .xvpics;
+			sourceTree = "<group>";
+		};
+		FCB5343D189FB8C3007E6151 /* 1 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB5343E189FB8C3007E6151 /* buggy.rgb */,
+				FCB5343F189FB8C3007E6151 /* Makefile */,
+				FCB53440189FB8C3007E6151 /* settings.xml */,
+			);
+			path = 1;
+			sourceTree = "<group>";
+		};
+		FCB53441189FB8C3007E6151 /* 2 */ = {
+			isa = PBXGroup;
+			children = (
+				FCB53442189FB8C3007E6151 /* cg-nascar-rwd.rgb */,
+				FCB53443189FB8C3007E6151 /* Makefile */,
+				FCB53444189FB8C3007E6151 /* settings.xml */,
+			);
+			path = 2;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -4681,6 +5722,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FCB533E4189FB038007E6151 /* common.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4695,6 +5737,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FCB52F64189FA8FC007E6151 /* common.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4713,6 +5756,35 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1362E80C11AE7F6800AF3D9A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FCB53213189FB00D007E6151 /* common.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B48D189FDEF400F96E81 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B498189FF67100F96E81 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B4A1189FF6ED00F96E81 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B4AD18A2548600F96E81 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -5055,14 +6127,88 @@
 			productReference = 8D1107320486CEB800E47090 /* Torcs.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FC53B48E189FDEF400F96E81 /* cylos1 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC53B490189FDEF400F96E81 /* Build configuration list for PBXNativeTarget "cylos1" */;
+			buildPhases = (
+				FC53B48B189FDEF400F96E81 /* Sources */,
+				FC53B48C189FDEF400F96E81 /* Frameworks */,
+				FC53B48D189FDEF400F96E81 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = cylos1;
+			productName = cylos1.so;
+			productReference = FC53B48F189FDEF400F96E81 /* cylos1.so */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		FC53B499189FF67100F96E81 /* K1999 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC53B49B189FF67100F96E81 /* Build configuration list for PBXNativeTarget "K1999" */;
+			buildPhases = (
+				FC53B496189FF67100F96E81 /* Sources */,
+				FC53B497189FF67100F96E81 /* Frameworks */,
+				FC53B498189FF67100F96E81 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = K1999;
+			productName = K1999;
+			productReference = FC53B49A189FF67100F96E81 /* K1999.so */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		FC53B4A2189FF6ED00F96E81 /* cylos2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC53B4A4189FF6ED00F96E81 /* Build configuration list for PBXNativeTarget "cylos2" */;
+			buildPhases = (
+				FC53B49F189FF6ED00F96E81 /* Sources */,
+				FC53B4A0189FF6ED00F96E81 /* Frameworks */,
+				FC53B4A1189FF6ED00F96E81 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = cylos2;
+			productName = cylos2;
+			productReference = FC53B4A3189FF6ED00F96E81 /* cylos2.so */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		FC53B4AE18A2548600F96E81 /* tanhoj */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC53B4B018A2548600F96E81 /* Build configuration list for PBXNativeTarget "tanhoj" */;
+			buildPhases = (
+				FC53B4AB18A2548600F96E81 /* Sources */,
+				FC53B4AC18A2548600F96E81 /* Frameworks */,
+				FC53B4AD18A2548600F96E81 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = tanhoj;
+			productName = tanhoj;
+			productReference = FC53B4AF18A2548600F96E81 /* tanhoj.so */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Torcs" */;
 			compatibilityVersion = "Xcode 2.4";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Torcs */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -5087,6 +6233,10 @@
 				1362E7BF11AE7ED600AF3D9A /* olethros.so */,
 				1362E7EB11AE7F4B00AF3D9A /* sparkle.so */,
 				1362E80911AE7F6800AF3D9A /* tita.so */,
+				FC53B48E189FDEF400F96E81 /* cylos1 */,
+				FC53B4A2189FF6ED00F96E81 /* cylos2 */,
+				FC53B499189FF67100F96E81 /* K1999 */,
+				FC53B4AE18A2548600F96E81 /* tanhoj */,
 			);
 		};
 /* End PBXProject section */
@@ -5155,7 +6305,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "patch -p1 -d \"$TORCS_BASE\" < torcs-1.3.1-mac.diff";
+			shellScript = "patch -p1 -d \"$TORCS_BASE\" < torcs-1.3.5-mac.diff";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -5386,14 +6536,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1362E75A11AE7E3D00AF3D9A /* pit.cpp in Sources */,
-				1362E75B11AE7E3D00AF3D9A /* spline.cpp in Sources */,
-				1362E75C11AE7E3D00AF3D9A /* learn.cpp in Sources */,
-				1362E75D11AE7E3D00AF3D9A /* strategy.cpp in Sources */,
-				1362E75E11AE7E3D00AF3D9A /* driver.cpp in Sources */,
-				1362E75F11AE7E3D00AF3D9A /* damned.cpp in Sources */,
-				1362E76011AE7E3D00AF3D9A /* opponent.cpp in Sources */,
-				1362E76111AE7E3D00AF3D9A /* cardata.cpp in Sources */,
+				FCB52FF4189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF2189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FEC189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FEA189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF6189FAC33007E6151 /* damned.cpp in Sources */,
+				FCB52FE6189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF8189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FE4189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FE8189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FEE189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF0189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FE2189FAC33007E6151 /* Makefile in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5401,11 +6555,29 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1362E77B11AE7E5C00AF3D9A /* mycar.cpp in Sources */,
-				1362E77C11AE7E5C00AF3D9A /* spline.cpp in Sources */,
-				1362E77D11AE7E5C00AF3D9A /* trackdesc.cpp in Sources */,
-				1362E77E11AE7E5C00AF3D9A /* pathfinder.cpp in Sources */,
-				1362E77F11AE7E5C00AF3D9A /* inferno.cpp in Sources */,
+				FCB533E6189FB038007E6151 /* Makefile in Sources */,
+				FCB533E0189FB038007E6151 /* Makefile in Sources */,
+				FCB533E3189FB038007E6151 /* common.cpp in Sources */,
+				FCB533DD189FB038007E6151 /* Makefile in Sources */,
+				FCB533DF189FB038007E6151 /* Makefile in Sources */,
+				FCB533D8189FB038007E6151 /* Makefile in Sources */,
+				FCB533E1189FB038007E6151 /* Makefile in Sources */,
+				FCB533D7189FB038007E6151 /* Makefile in Sources */,
+				FCB533D4189FB038007E6151 /* Makefile in Sources */,
+				FCB533D9189FB038007E6151 /* Makefile in Sources */,
+				FCB533D3189FB038007E6151 /* Makefile in Sources */,
+				FCB533DE189FB038007E6151 /* Makefile in Sources */,
+				FCB533E2189FB038007E6151 /* Makefile in Sources */,
+				FCB533D1189FB038007E6151 /* Makefile in Sources */,
+				FCB533E5189FB038007E6151 /* inferno.cpp in Sources */,
+				FCB533DA189FB038007E6151 /* Makefile in Sources */,
+				FCB533D0189FB038007E6151 /* Makefile in Sources */,
+				FCB533D2189FB038007E6151 /* Makefile in Sources */,
+				FCB533D5189FB038007E6151 /* Makefile in Sources */,
+				FCB533DB189FB038007E6151 /* Makefile in Sources */,
+				FCB533D6189FB038007E6151 /* Makefile in Sources */,
+				FCB533DC189FB038007E6151 /* Makefile in Sources */,
+				FCB533CF189FB038007E6151 /* Makefile in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5422,11 +6594,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1362E7BA11AE7ECA00AF3D9A /* mycar.cpp in Sources */,
-				1362E7BB11AE7ECA00AF3D9A /* spline.cpp in Sources */,
-				1362E7BC11AE7ECA00AF3D9A /* pathfinder.cpp in Sources */,
-				1362E7BD11AE7ECA00AF3D9A /* trackdesc.cpp in Sources */,
-				1362E7BE11AE7ECA00AF3D9A /* lliaw.cpp in Sources */,
+				FCB52F66189FA8FC007E6151 /* Makefile in Sources */,
+				FCB52F67189FA8FC007E6151 /* Makefile in Sources */,
+				FCB52F65189FA8FC007E6151 /* lliaw.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5464,11 +6634,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1362E82911AE7FAD00AF3D9A /* tita.cpp in Sources */,
-				1362E82A11AE7FAD00AF3D9A /* mycar.cpp in Sources */,
-				1362E82B11AE7FAD00AF3D9A /* spline.cpp in Sources */,
-				1362E82C11AE7FAD00AF3D9A /* pathfinder.cpp in Sources */,
-				1362E82D11AE7FAD00AF3D9A /* trackdesc.cpp in Sources */,
+				FCB53216189FB00D007E6151 /* Makefile in Sources */,
+				FCB52FED189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FEB189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FE5189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF7189FAC33007E6151 /* damned.cpp in Sources */,
+				FCB52FEF189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FE3189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF9189FAC33007E6151 /* Makefile in Sources */,
+				FCB53214189FB00D007E6151 /* Makefile in Sources */,
+				FCB52FF1189FAC33007E6151 /* Makefile in Sources */,
+				FCB53215189FB00D007E6151 /* tita.cpp in Sources */,
+				FCB52FE7189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FF3189FAC33007E6151 /* Makefile in Sources */,
+				FCB52FE9189FAC33007E6151 /* Makefile in Sources */,
+				FCB53212189FB00D007E6151 /* common.cpp in Sources */,
+				FCB52FF5189FAC33007E6151 /* Makefile in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5478,6 +6659,41 @@
 			files = (
 				1362F80711AF009300AF3D9A /* linuxspec.cpp in Sources */,
 				1362F80911AF009300AF3D9A /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B48B189FDEF400F96E81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B494189FDF9900F96E81 /* cylos1.cpp in Sources */,
+				FC53B493189FDF9900F96E81 /* common.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B496189FF67100F96E81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B49E189FF69500F96E81 /* K1999.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B49F189FF6ED00F96E81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B4A7189FF71100F96E81 /* common.cpp in Sources */,
+				FC53B4A8189FF71100F96E81 /* cylos2.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC53B4AB18A2548600F96E81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC53B4B318A2557E00F96E81 /* common.cpp in Sources */,
+				FC53B4B418A2557E00F96E81 /* tanhoj.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5665,6 +6881,7 @@
 		0F2F53F80DA742EC000D370D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -5687,12 +6904,14 @@
 				PREBINDING = NO;
 				PRELINK_FLAGS = "";
 				PRODUCT_NAME = track;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		0F2F53F90DA742EC000D370D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -5710,6 +6929,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/modules/track";
 				PREBINDING = NO;
 				PRODUCT_NAME = track;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5717,6 +6937,7 @@
 		0FAEA3880DA9D9C2003539AB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -5741,6 +6962,7 @@
 				PREBINDING = NO;
 				PRELINK_FLAGS = "";
 				PRODUCT_NAME = ssggraph;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -5748,6 +6970,7 @@
 		0FAEA3890DA9D9C2003539AB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -5770,6 +6993,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/modules/graphic";
 				PREBINDING = NO;
 				PRODUCT_NAME = ssggraph;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5777,6 +7001,7 @@
 		0FD99F810DAB1E46008A07B8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -5798,6 +7023,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = human;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -5805,6 +7031,7 @@
 		0FD99F820DAB1E46008A07B8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -5820,6 +7047,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/human";
 				PREBINDING = NO;
 				PRODUCT_NAME = human;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5827,6 +7055,7 @@
 		0FD99F9E0DAB1FFE008A07B8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -5849,6 +7078,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = simuv2;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -5856,6 +7086,7 @@
 		0FD99F9F0DAB1FFE008A07B8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -5872,6 +7103,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/modules/simu";
 				PREBINDING = NO;
 				PRODUCT_NAME = simuv2;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5879,6 +7111,7 @@
 		0FD9A0160DAB22BC008A07B8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -5895,6 +7128,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/modules/telemetry";
 				PREBINDING = NO;
 				PRODUCT_NAME = telemetry;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -5902,6 +7136,7 @@
 		0FD9A0170DAB22BC008A07B8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -5919,6 +7154,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/modules/telemetry";
 				PREBINDING = NO;
 				PRODUCT_NAME = telemetry;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5926,21 +7162,25 @@
 		0FE71DEE0DAC5942008D6F50 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				PRODUCT_NAME = "Dynamic Libraries";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		0FE71DEF0DAC5942008D6F50 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				PRODUCT_NAME = "Dynamic Libraries";
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5948,6 +7188,7 @@
 		0FE722EC0DAC7C0B008D6F50 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				EXECUTABLE_PREFIX = lib;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5961,12 +7202,14 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = "@executable_path/../Resources";
 				PRODUCT_NAME = Torcs;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		0FE722ED0DAC7C0B008D6F50 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_PREFIX = lib;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5980,6 +7223,7 @@
 				INSTALL_PATH = "@executable_path/../Resources";
 				PREBINDING = NO;
 				PRODUCT_NAME = Torcs;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -5987,6 +7231,7 @@
 		1362E1F511AE7B5C00AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6008,6 +7253,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = berniw;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6015,6 +7261,7 @@
 		1362E1F611AE7B5C00AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6030,6 +7277,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/berniw";
 				PREBINDING = NO;
 				PRODUCT_NAME = berniw;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6037,6 +7285,7 @@
 		1362E6EA11AE7D9100AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6058,6 +7307,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = berniw2;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6065,6 +7315,7 @@
 		1362E6EB11AE7D9100AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6080,6 +7331,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/berniw2";
 				PREBINDING = NO;
 				PRODUCT_NAME = berniw2;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6087,6 +7339,7 @@
 		1362E70511AE7DB300AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6108,6 +7361,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = berniw3;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6115,6 +7369,7 @@
 		1362E70611AE7DB300AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6130,6 +7385,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/berniw3";
 				PREBINDING = NO;
 				PRODUCT_NAME = berniw3;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6137,6 +7393,7 @@
 		1362E72011AE7DD600AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6158,6 +7415,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = bt;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6165,6 +7423,7 @@
 		1362E72111AE7DD600AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6180,6 +7439,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/bt";
 				PREBINDING = NO;
 				PRODUCT_NAME = bt;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6187,6 +7447,7 @@
 		1362E75711AE7E2700AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6208,6 +7469,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = damned;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6215,6 +7477,7 @@
 		1362E75811AE7E2700AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6230,6 +7493,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/damned";
 				PREBINDING = NO;
 				PRODUCT_NAME = damned;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6237,6 +7501,7 @@
 		1362E77811AE7E4A00AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6258,6 +7523,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = inferno;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6265,6 +7531,7 @@
 		1362E77911AE7E4A00AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6280,6 +7547,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
 				PREBINDING = NO;
 				PRODUCT_NAME = inferno;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6287,6 +7555,7 @@
 		1362E79011AE7E6200AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6308,6 +7577,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = inferno2;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6315,6 +7585,7 @@
 		1362E79111AE7E6200AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6330,6 +7601,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
 				PREBINDING = NO;
 				PRODUCT_NAME = inferno2;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6337,6 +7609,7 @@
 		1362E7B711AE7EB600AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6358,6 +7631,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = lliaw;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6365,6 +7639,7 @@
 		1362E7B811AE7EB600AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6380,6 +7655,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
 				PREBINDING = NO;
 				PRODUCT_NAME = lliaw;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6387,6 +7663,7 @@
 		1362E7CF11AE7ED600AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6408,6 +7685,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = olethros;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6415,6 +7693,7 @@
 		1362E7D011AE7ED600AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6430,6 +7709,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
 				PREBINDING = NO;
 				PRODUCT_NAME = olethros;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6437,6 +7717,7 @@
 		1362E80111AE7F4B00AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6458,6 +7739,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = sparkle;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6465,6 +7747,7 @@
 		1362E80211AE7F4B00AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6480,6 +7763,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
 				PREBINDING = NO;
 				PRODUCT_NAME = sparkle;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6487,6 +7771,7 @@
 		1362E81911AE7F6800AF3D9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -6508,6 +7793,7 @@
 				MACH_O_TYPE = mh_bundle;
 				PREBINDING = NO;
 				PRODUCT_NAME = tita;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -6515,6 +7801,7 @@
 		1362E81A11AE7F6800AF3D9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				EXECUTABLE_EXTENSION = so;
 				EXECUTABLE_PREFIX = "";
@@ -6530,6 +7817,7 @@
 				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
 				PREBINDING = NO;
 				PRODUCT_NAME = tita;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6541,6 +7829,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				PRODUCT_NAME = "Apply patch";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -6551,6 +7840,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				PRODUCT_NAME = "Apply patch";
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -6558,6 +7848,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				EXPORTED_SYMBOLS_FILE = "";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6570,10 +7861,12 @@
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = __APPLE__;
 				GENERATE_MASTER_OBJECT_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				KEEP_PRIVATE_EXTERNS = NO;
 				PRODUCT_NAME = Torcs;
+				SDKROOT = macosx;
 				STRIP_STYLE = debugging;
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = NO;
@@ -6583,6 +7876,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_2)",
@@ -6591,9 +7885,11 @@
 				FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_2 = "\"$(SRCROOT)/Frameworks\"";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_MODEL_TUNING = G5;
+				GCC_PREPROCESSOR_DEFINITIONS = __APPLE__;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = Torcs;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -6601,8 +7897,7 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1 = "ppc i386";
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"@executable_path/../Frameworks",
@@ -6654,6 +7949,319 @@
 				PREBINDING = NO;
 				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
 				TORCS_BASE = $SRCROOT/..;
+			};
+			name = Release;
+		};
+		FC53B491189FDEF400F96E81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
+				CLANG_CXX_LIBRARY = "compiler-default";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_COMPATIBILITY_VERSION = "";
+				DYLIB_CURRENT_VERSION = "";
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GENERATE_MASTER_OBJECT_FILE = YES;
+				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
+				MACH_O_TYPE = mh_bundle;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FC53B492189FDEF400F96E81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
+				CLANG_CXX_LIBRARY = "compiler-default";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_NS_ASSERTIONS = NO;
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_2)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		FC53B49C189FF67100F96E81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FC53B49D189FF67100F96E81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		FC53B4A5189FF6ED00F96E81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
+				CLANG_CXX_LIBRARY = "compiler-default";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_COMPATIBILITY_VERSION = "";
+				DYLIB_CURRENT_VERSION = "";
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GENERATE_MASTER_OBJECT_FILE = YES;
+				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
+				MACH_O_TYPE = mh_bundle;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FC53B4A6189FF6ED00F96E81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
+				CLANG_CXX_LIBRARY = "compiler-default";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_NS_ASSERTIONS = NO;
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INSTALL_PATH = "@executable_path/../Resources/drivers/$(PRODUCT_NAME)";
+				MACH_O_TYPE = mh_dylib;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		FC53B4B118A2548600F96E81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FC53B4B218A2548600F96E81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				EXECUTABLE_EXTENSION = so;
+				EXECUTABLE_PREFIX = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -6845,6 +8453,42 @@
 			buildConfigurations = (
 				C01FCF4F08A954540054247B /* Debug */,
 				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC53B490189FDEF400F96E81 /* Build configuration list for PBXNativeTarget "cylos1" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC53B491189FDEF400F96E81 /* Debug */,
+				FC53B492189FDEF400F96E81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC53B49B189FF67100F96E81 /* Build configuration list for PBXNativeTarget "K1999" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC53B49C189FF67100F96E81 /* Debug */,
+				FC53B49D189FF67100F96E81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC53B4A4189FF6ED00F96E81 /* Build configuration list for PBXNativeTarget "cylos2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC53B4A5189FF6ED00F96E81 /* Debug */,
+				FC53B4A6189FF6ED00F96E81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC53B4B018A2548600F96E81 /* Build configuration list for PBXNativeTarget "tanhoj" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC53B4B118A2548600F96E81 /* Debug */,
+				FC53B4B218A2548600F96E81 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/torcs-1.3.5-mac.diff
+++ b/torcs-1.3.5-mac.diff
@@ -12,18 +12,6 @@ diff -ru torcs-1.3.1/data/tracks/aalborg/Makefile torcs-1.3.1-mac/data/tracks/aa
  
  data-tracks-road_PKGFILES	= $(DATA)
  
-diff -ru torcs-1.3.1/data/tracks/road/alpine-2/Makefile torcs-1.3.1-mac/data/tracks/road/alpine-2/Makefile
---- torcs-1.3.1/data/tracks/road/alpine-2/Makefile	2008-06-05 01:09:11.000000000 +0200
-+++ torcs-1.3.1-mac/data/tracks/road/alpine-2/Makefile	2010-06-16 00:23:09.000000000 +0200
-@@ -23,7 +23,7 @@
- 			arbor2_n.rgb concrete2.rgb shadow2.rgb tr-stone-wall.rgb truck_arbor_berniw_n.rgb \
- 			truck_arbor_dummy_n.rgb truck_arbor_hymie_n.rgb truck_arbor_inferno_n.rgb \
- 			truck_arbor_mouse_n.rgb truck_arbor_ole_n.rgb truck_arbor_speedy_n.rgb \
--			truck_arbor_tp_n.rgb truck_arbor_usr_n.rgb alpine-2.png armco2_arbor.png \
-+			truck_arbor_tp_n.rgb truck_arbor_usr_n.rgb armco2_arbor.png \
- 			armco_snow_arbor.png armcoturn_arbor.png background.png BARS_tree_n.png BLBDBK.png \
- 			BLDG05_tree.png brick01.png cliff.png CMNTA.png concdark.png CONCRE.png \
- 			concrete01.png concwall2.png concwall.png GRDRA_tree_n.png ice.png LOGOMELA.png \
 diff -ru torcs-1.3.1/data/tracks/road/forza/Makefile torcs-1.3.1-mac/data/tracks/road/forza/Makefile
 --- torcs-1.3.1/data/tracks/road/forza/Makefile	2008-02-24 13:55:08.000000000 +0100
 +++ torcs-1.3.1-mac/data/tracks/road/forza/Makefile	2010-06-16 00:23:09.000000000 +0200


### PR DESCRIPTION
The patch updates MacTorcs to enable it to patch the latest version of Torcs source (1.3.5) so that it can be built on Mountain Lion 10.8 and Mavericks 10.9 using Xcode 5.0 and the latest OS X SDKs.
